### PR TITLE
fix: files buffers handling

### DIFF
--- a/ISSUE_ANALYSIS.md
+++ b/ISSUE_ANALYSIS.md
@@ -1,0 +1,374 @@
+# Análisis Completo: Error `buf.readUInt8 is not a function` con file-type v15
+
+## Resumen Ejecutivo
+
+El servicio está experimentando un error persistente al detectar el tipo MIME de archivos usando `file-type` v15. El error ocurre específicamente con archivos grandes (ej: WebM de 177KB) aunque el buffer que se pasa es válido según todas las verificaciones.
+
+**Error:** `TypeError: buf.readUInt8 is not a function`  
+**Ubicación:** Dentro de `strtok3/lib/AbstractTokenizer.js` (usado por `file-type` v15)  
+**Archivo problemático:** `REMOTE_WebM_VP9_1920x1080_30fps.webm` (177,504 bytes)
+
+## Evidencia de los Logs
+
+### Logs que Confirman Buffer Válido
+
+```
+detectMimeTypeFromBuffer: Detection buffer {
+  "originalLength": 177504,
+  "detectionLength": 4100,
+  "bytesUsed": 4100,
+  "properType": "Buffer",
+  "properIsBuffer": true,
+  "properHasReadUInt8": true,
+  "properProtoHasReadUInt8": true
+}
+```
+
+**Observación crítica:** El buffer que pasamos a `fromBuffer` es completamente válido:
+- ✅ Es un Buffer de Node.js (`properIsBuffer: true`)
+- ✅ Tiene el método `readUInt8` (`properHasReadUInt8: true`)
+- ✅ El prototipo tiene el método (`properProtoHasReadUInt8: true`)
+- ✅ Tiene el tamaño correcto (4100 bytes)
+
+### Stack Trace del Error
+
+```
+TypeError: buf.readUInt8 is not a function
+  at Object.get (/app/node_modules/token-types/lib/index.js:12:20)
+  at BufferTokenizer.peekNumber (/app/node_modules/strtok3/lib/AbstractTokenizer.js:63:22)
+  at async readField (/app/node_modules/file-type/core.js:679:16)
+  at async readElement (/app/node_modules/file-type/core.js:694:15)
+  at async _fromTokenizer (/app/node_modules/file-type/core.js:716:14)
+```
+
+**Observación crítica:** El error ocurre DENTRO de `strtok3`, no en nuestro código.
+
+## Análisis de la Causa Raíz
+
+### Arquitectura de file-type v15
+
+`file-type` v15 usa internamente:
+1. `strtok3` - Biblioteca para tokenizar streams/buffers
+2. `token-types` - Tipos de tokens para leer datos estructurados
+3. `BufferTokenizer` - Wrapper de `strtok3` que crea vistas del buffer
+
+### Hipótesis Principales
+
+#### Hipótesis 1: Buffer Views/Subarrays en strtok3 (MÁS PROBABLE)
+
+**Descripción:** `strtok3` crea vistas/subarrays del buffer original para leer datos de forma eficiente. Estas vistas pueden perder los métodos de Buffer.
+
+**Evidencia:**
+- El error ocurre en `BufferTokenizer.peekNumber` que probablemente crea una vista del buffer
+- Nuestro buffer es válido antes de pasarlo a `fromBuffer`
+- El error ocurre después de que `file-type` procesa el buffer internamente
+
+**Por qué podría pasar:**
+- `strtok3` puede usar `buffer.slice()` o `buffer.subarray()` que crean vistas
+- Las vistas de Buffer pueden no tener todos los métodos si se crean de cierta manera
+- Node.js puede optimizar buffers grandes de forma diferente
+
+**Cómo verificar:**
+- Inspeccionar el código fuente de `strtok3` y `file-type` v15
+- Ver cómo `BufferTokenizer` maneja el buffer internamente
+- Verificar si hay issues conocidos en los repositorios de estas librerías
+
+#### Hipótesis 2: Incompatibilidad de Versiones de Node.js
+
+**Descripción:** La versión de Node.js en producción puede tener diferencias en cómo maneja Buffers que causan problemas con `strtok3`.
+
+**Evidencia:**
+- El problema solo ocurre en producción, no necesariamente en desarrollo
+- Diferentes versiones de Node.js pueden tener implementaciones diferentes de Buffer
+
+**Cómo verificar:**
+- Verificar la versión de Node.js en producción vs desarrollo
+- Revisar changelog de Node.js para cambios en Buffer API
+- Probar con diferentes versiones de Node.js
+
+#### Hipótesis 3: Buffer Pooling o Memory Management
+
+**Descripción:** Node.js puede estar reutilizando buffers de un pool interno, y `strtok3` puede estar recibiendo un buffer del pool que no tiene todos los métodos.
+
+**Evidencia:**
+- El problema ocurre con archivos grandes (177KB)
+- Node.js usa buffer pooling para optimización
+- `Buffer.from()` puede devolver buffers del pool
+
+**Cómo verificar:**
+- Crear buffers con `Buffer.allocUnsafe()` vs `Buffer.from()`
+- Verificar si el problema persiste con diferentes métodos de creación de buffers
+
+#### Hipótesis 4: Bug en file-type v15 o strtok3
+
+**Descripción:** Puede haber un bug conocido en `file-type` v15 o `strtok3` que causa este problema.
+
+**Evidencia:**
+- El error es consistente y reproducible
+- Ocurre específicamente con ciertos tipos de archivos (WebM)
+
+**Cómo verificar:**
+- Buscar issues en GitHub de `file-type` y `strtok3`
+- Verificar si hay versiones más recientes que lo solucionen
+- Probar con versiones anteriores de `file-type`
+
+#### Hipótesis 5: Problema con Buffer.slice()
+
+**Descripción:** `buffer.slice()` puede estar creando una vista que no mantiene los métodos cuando se pasa a través de múltiples capas.
+
+**Evidencia:**
+- Usamos `buffer.slice(0, bytesToUse)` para crear el buffer de detección
+- Aunque luego hacemos `Buffer.from()`, puede haber algún problema con el slice original
+
+**Cómo verificar:**
+- Probar creando el buffer de detección sin usar `slice()`
+- Usar `Buffer.allocUnsafe()` y copiar los bytes manualmente
+
+## Soluciones Alternativas Propuestas
+
+### Solución 1: Usar `fromStream` en lugar de `fromBuffer` ⭐ RECOMENDADA
+
+**Descripción:** `file-type` v15 **SÍ tiene** la función `fromStream` que evita cargar todo en memoria.
+
+**✅ Verificado:** `file-type` v15 exporta: `['fromFile', 'fromStream', 'fromTokenizer', 'fromBuffer', 'stream']`
+
+**Pros:**
+- Evita problemas con buffers grandes completamente
+- Más eficiente en memoria (no carga todo el archivo)
+- Puede evitar el problema de strtok3 con buffers ya que trabaja directamente con streams
+- No requiere buffering completo del archivo
+
+**Contras:**
+- Requiere modificar el flujo para pasar un stream en lugar de buffer
+- El stream puede consumirse (necesita clonarse o recrearse para S3 upload)
+
+**Implementación:**
+```typescript
+import { fromStream } from 'file-type'
+import { PassThrough } from 'stream'
+
+async function detectMimeTypeFromStream(stream: Readable): Promise<string> {
+  // Opción 1: Si podemos leer el stream dos veces (ej: desde S3)
+  const mime = await fromStream(stream)
+  return mime?.mime || 'application/octet-stream'
+}
+
+// Opción 2: Si necesitamos preservar el stream para S3 upload
+async function detectMimeTypeWithStreamTee(stream: Readable): Promise<{ mime: string, preservedStream: Readable }> {
+  // Crear un tee del stream
+  const passThrough = new PassThrough()
+  const teeStream = stream.pipe(passThrough)
+  
+  // Detectar MIME desde el tee
+  const mime = await fromStream(teeStream)
+  
+  // El stream original sigue disponible para S3
+  return {
+    mime: mime?.mime || 'application/octet-stream',
+    preservedStream: stream
+  }
+}
+```
+
+**Consideraciones:**
+- `fromStream` consume el stream, así que si necesitamos el stream después para S3, tenemos opciones:
+  1. Detectar MIME primero, luego recrear el stream desde S3 (si es posible)
+  2. Usar un stream tee/clone para preservar el original
+  3. Bufferizar el stream de todas formas, pero detectar MIME antes del buffering completo usando los primeros chunks
+
+### Solución 2: Crear Buffer con `Buffer.allocUnsafe()` y copiar manualmente
+
+**Descripción:** En lugar de usar `Buffer.from(buffer.slice())`, crear un buffer nuevo y copiar los bytes manualmente.
+
+**Pros:**
+- Garantiza un buffer completamente nuevo
+- Evita problemas con vistas/subarrays
+- Control total sobre la creación del buffer
+
+**Contras:**
+- Más código
+- Puede no resolver el problema si es interno de strtok3
+
+**Implementación:**
+```typescript
+const maxBytesForDetection = 4100
+const bytesToUse = Math.min(maxBytesForDetection, buffer.length)
+const detectionBuffer = Buffer.allocUnsafe(bytesToUse)
+buffer.copy(detectionBuffer, 0, 0, bytesToUse)
+```
+
+### Solución 3: Usar una versión diferente de file-type
+
+**Descripción:** Probar con `file-type` v16+ o v14 si están disponibles, o usar una alternativa como `mime-types`.
+
+**Pros:**
+- Puede tener el bug solucionado
+- Alternativas pueden ser más estables
+
+**Contras:**
+- Puede requerir cambios en la API
+- Puede perder funcionalidad
+- Necesita investigación de compatibilidad
+
+**Alternativas:**
+- `file-type` v16+ (si existe)
+- `mime-types` + extensión de archivo
+- `mmmagic` (requiere bindings nativos)
+
+### Solución 4: Detección basada en extensión de archivo
+
+**Descripción:** Si el nombre del archivo está disponible, usar la extensión como fallback cuando `file-type` falle.
+
+**Pros:**
+- Simple y confiable
+- No depende de buffers
+
+**Contras:**
+- Menos preciso que detección por contenido
+- Requiere que el nombre del archivo esté disponible
+
+**Implementación:**
+```typescript
+import mime from 'mime-types'
+
+async function detectMimeType(buffer: Buffer, filename?: string): Promise<string> {
+  try {
+    const mime = await fromBuffer(buffer)
+    return mime?.mime || 'application/octet-stream'
+  } catch (error) {
+    if (filename) {
+      const mimeType = mime.lookup(filename)
+      if (mimeType) return mimeType
+    }
+    return 'application/octet-stream'
+  }
+}
+```
+
+### Solución 5: Wrapper con retry y diferentes métodos
+
+**Descripción:** Crear un wrapper que intente múltiples métodos de detección con fallbacks.
+
+**Pros:**
+- Robusto ante fallos
+- Múltiples estrategias de detección
+
+**Contras:**
+- Más complejo
+- Puede ser más lento
+
+**Implementación:**
+```typescript
+async function detectMimeTypeRobust(
+  buffer: Buffer, 
+  stream: Readable, 
+  filename?: string
+): Promise<string> {
+  // Método 1: fromBuffer con buffer pequeño
+  try {
+    const detectionBuffer = Buffer.allocUnsafe(4100)
+    buffer.copy(detectionBuffer, 0, 0, Math.min(4100, buffer.length))
+    const mime = await fromBuffer(detectionBuffer)
+    if (mime?.mime) return mime.mime
+  } catch (error) {
+    logger.warn('fromBuffer failed, trying alternatives', { error })
+  }
+
+  // Método 2: fromStream si está disponible
+  try {
+    const streamCopy = stream // Necesitaríamos clonar el stream
+    const mime = await fromStream(streamCopy)
+    if (mime?.mime) return mime.mime
+  } catch (error) {
+    logger.warn('fromStream failed', { error })
+  }
+
+  // Método 3: Por extensión
+  if (filename) {
+    const mimeType = mime.lookup(filename)
+    if (mimeType) return mimeType
+  }
+
+  return 'application/octet-stream'
+}
+```
+
+### Solución 6: Investigar y reportar bug
+
+**Descripción:** Si confirmamos que es un bug en `file-type`/`strtok3`, reportarlo y usar un workaround temporal.
+
+**Pros:**
+- Ayuda a la comunidad
+- Puede resultar en una solución oficial
+
+**Contras:**
+- No resuelve el problema inmediatamente
+- Requiere investigación adicional
+
+## Recomendaciones
+
+### Inmediatas (Quick Wins)
+
+1. **⭐ Implementar Solución 1:** Usar `fromStream` en lugar de `fromBuffer`
+   - **ALTA PRIORIDAD** - Evita el problema completamente
+   - Ya verificado que existe en v15
+   - Más eficiente en memoria
+   - Requiere modificar el flujo pero es la solución más robusta
+
+2. **Implementar Solución 2:** Crear buffer con `Buffer.allocUnsafe()` y copiar manualmente (si fromStream no funciona)
+   - Bajo riesgo
+   - Fácil de implementar
+   - Puede resolver el problema
+
+3. **Implementar Solución 4:** Agregar fallback por extensión de archivo
+   - Proporciona resiliencia
+   - No requiere cambios grandes
+   - Mejora la experiencia del usuario
+
+### Investigación Necesaria
+
+1. **✅ COMPLETADO:** Verificar si `fromStream` existe en file-type v15
+   - **Resultado:** `fromStream` SÍ existe en file-type v15
+   - Exportado como: `['fromFile', 'fromStream', 'fromTokenizer', 'fromBuffer', 'stream']`
+
+2. **Buscar issues conocidos:**
+   - GitHub: `sindresorhus/file-type`
+   - GitHub: `Borewit/strtok3`
+   - Stack Overflow
+   - Node.js issues
+
+3. **Probar con diferentes métodos de creación de Buffer:**
+   - `Buffer.from()`
+   - `Buffer.allocUnsafe()` + `copy()`
+   - `Buffer.alloc()` + `copy()`
+   - `Buffer.concat()` con buffers pequeños
+
+4. **Verificar versión de Node.js en producción:**
+   - Comparar con versión de desarrollo
+   - Revisar changelog de Node.js
+
+### Próximos Pasos Sugeridos
+
+1. ✅ **Completado:** Implementar uso de primeros bytes del buffer (no resolvió el problema)
+2. ✅ **Completado:** Investigar si `fromStream` está disponible (SÍ está disponible)
+3. 🔥 **ALTA PRIORIDAD:** Implementar `fromStream` en lugar de `fromBuffer`
+4. ⏳ **Pendiente:** Probar `Buffer.allocUnsafe()` + `copy()` (si fromStream no funciona)
+5. ⏳ **Pendiente:** Implementar fallback por extensión
+6. ⏳ **Pendiente:** Buscar issues conocidos en GitHub
+7. ⏳ **Pendiente:** Considerar downgrade/upgrade de `file-type` si es necesario
+
+## Conclusión
+
+El problema es complejo y parece estar relacionado con cómo `strtok3` (usado por `file-type` v15) maneja los buffers internamente. Aunque nuestro buffer es válido antes de pasarlo a `fromBuffer`, algo dentro de `strtok3` está creando una vista o subarray que pierde los métodos de Buffer.
+
+**Próxima acción recomendada:** Implementar la **Solución 1 (`fromStream`)** ya que está disponible en file-type v15 y evita completamente el problema con buffers. Si el stream se consume, podemos detectar MIME antes del buffering completo, o usar un stream clonado/tee para mantener el stream original para S3 upload.
+
+**Alternativa si fromStream no funciona:** Implementar la Solución 2 (Buffer.allocUnsafe + copy) combinada con la Solución 4 (fallback por extensión) para tener una solución robusta.
+
+## Referencias
+
+- [file-type v15 Documentation](https://github.com/sindresorhus/file-type)
+- [strtok3 Repository](https://github.com/Borewit/strtok3)
+- [Node.js Buffer API](https://nodejs.org/api/buffer.html)
+- [token-types Repository](https://github.com/Borewit/token-types)
+

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -22,17 +22,29 @@ async function streamToBuffer(stream: Readable): Promise<Buffer> {
   const chunks: Buffer[] = []
   for await (const chunk of stream) {
     // Ensure chunk is converted to Buffer (handles Uint8Array, Buffer, etc.)
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    chunks.push(bufferChunk)
   }
   return Buffer.concat(chunks)
 }
 
 /**
  * Detects the MIME type from a buffer.
+ * Uses only the first bytes of the buffer for detection.
+ * file-type v15 only needs the first ~4100 bytes to detect any file type.
  */
-async function detectMimeTypeFromBuffer(buffer: Buffer): Promise<string> {
-  const mime = await fromBuffer(buffer)
-  return mime?.mime || 'application/octet-stream'
+async function detectMimeTypeFromBuffer(buffer: Buffer | Uint8Array): Promise<string> {
+  // Use magic bytes from end of buffer to detect MIME type
+  const maxBytesForDetection = 4100
+  const bytesToUse = Math.min(maxBytesForDetection, buffer.length)
+  const detectionBuffer = Buffer.from(buffer.slice(0, bytesToUse))
+
+  try {
+    const mime = await fromBuffer(detectionBuffer)
+    return mime?.mime || 'application/octet-stream'
+  } catch (error: any) {
+    return 'application/octet-stream'
+  }
 }
 
 /**
@@ -75,7 +87,7 @@ export async function createS3BasedFileSystemContentStorage(
   }
 
   async function storeStream(id: string, stream: Readable): Promise<void> {
-    // Buffer the entire stream to avoid consuming it multiple times
+    // Buffer the entire stream to detect MIME type and upload
     const fullBuffer = await streamToBuffer(stream)
 
     // Detect MIME type from the buffer
@@ -86,8 +98,8 @@ export async function createS3BasedFileSystemContentStorage(
       .upload({
         Bucket,
         Key: getKey(id),
-        Body: bufferToStream(fullBuffer), // Recreate stream from buffer for S3 upload
-        ContentType: mimeType // Set the detected MIME type
+        Body: bufferToStream(fullBuffer),
+        ContentType: mimeType
       })
       .promise()
   }

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -21,7 +21,8 @@ function bufferToStream(buffer: Buffer): Readable {
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
   const chunks: Buffer[] = []
   for await (const chunk of stream) {
-    chunks.push(chunk)
+    // Ensure chunk is converted to Buffer (handles Uint8Array, Buffer, etc.)
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
   }
   return Buffer.concat(chunks)
 }


### PR DESCRIPTION
This PR fixes an issue where the library used to automatically detect MIME types fails when handling webm files. When detection fails, the upload now falls back to the application/octet-stream MIME type.