### PR TITLE
feat: add support for range requests

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -191,7 +191,13 @@ export async function createFolderBasedFileSystemContentStorage(
           if (!decompressPromise) {
             decompressPromise = (async () => {
               const decompressed = await streamToBuffer(await gzipItem.asStream())
-              await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
+              try {
+                await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
+              } catch (err) {
+                // Remove partial file to prevent serving corrupt data
+                await noFailUnlink(uncompressedPath)
+                throw err
+              }
 
               const size = decompressed.length
               decompressCache.set(uncompressedPath, { size, lastAccess: Date.now() })
@@ -266,7 +272,12 @@ export async function createFolderBasedFileSystemContentStorage(
         clearInterval(evictionTimer)
         evictionTimer = undefined
       }
-      await evictCache()
+      // Evict all cached files on shutdown to prevent disk leaks across restarts
+      for (const [filePath, entry] of decompressCache) {
+        await noFailUnlink(filePath)
+        totalCacheSize -= entry.size
+        decompressCache.delete(filePath)
+      }
     },
     storeStream,
     retrieve,

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -50,6 +50,9 @@ export async function createFolderBasedFileSystemContentStorage(
   const decompressCache = new Map<string, { size: number; lastAccess: number }>()
   let totalCacheSize = 0
 
+  // Concurrency guard: prevents multiple simultaneous decompressions of the same file
+  const inflightDecompressions = new Map<string, Promise<void>>()
+
   async function evictCache() {
     const now = Date.now()
 
@@ -177,15 +180,27 @@ export async function createFolderBasedFileSystemContentStorage(
             throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
           }
 
-          // Decompress to disk
           const uncompressedPath = await getFilePath(id)
-          const decompressed = await streamToBuffer(await gzipItem.asStream())
-          await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
 
-          // Track in cache
-          const size = decompressed.length
-          decompressCache.set(uncompressedPath, { size, lastAccess: Date.now() })
-          totalCacheSize += size
+          // Wait for any in-flight decompression of the same file, or start one
+          if (inflightDecompressions.has(uncompressedPath)) {
+            await inflightDecompressions.get(uncompressedPath)
+          } else {
+            const decompressPromise = (async () => {
+              const decompressed = await streamToBuffer(await gzipItem.asStream())
+              await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
+
+              const size = decompressed.length
+              decompressCache.set(uncompressedPath, { size, lastAccess: Date.now() })
+              totalCacheSize += size
+            })()
+            inflightDecompressions.set(uncompressedPath, decompressPromise)
+            try {
+              await decompressPromise
+            } finally {
+              inflightDecompressions.delete(uncompressedPath)
+            }
+          }
 
           // Serve range from the cached uncompressed file
           contentItem = await retrieveWithEncoding(id, null, range)

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -93,11 +93,8 @@ export async function createFolderBasedFileSystemContentStorage(
   const retrieve = async (id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> => {
     try {
       let contentItem: ContentItem | undefined = undefined
-
       if (!range) contentItem = await retrieveWithEncoding(id, 'gzip')
-
       if (!contentItem) contentItem = await retrieveWithEncoding(id, null, range)
-
       return contentItem
     } catch (error: any) {
       logger.error(error)

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -59,8 +59,9 @@ export async function createFolderBasedFileSystemContentStorage(
     // TTL eviction
     for (const [filePath, entry] of decompressCache) {
       if (now - entry.lastAccess > CACHE_TTL) {
-        await noFailUnlink(filePath)
-        totalCacheSize -= entry.size
+        if (await noFailUnlink(filePath)) {
+          totalCacheSize -= entry.size
+        }
         decompressCache.delete(filePath)
       }
     }
@@ -70,8 +71,9 @@ export async function createFolderBasedFileSystemContentStorage(
       const sorted = [...decompressCache.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess)
       for (const [filePath, entry] of sorted) {
         if (totalCacheSize <= CACHE_MAX_SIZE) break
-        await noFailUnlink(filePath)
-        totalCacheSize -= entry.size
+        if (await noFailUnlink(filePath)) {
+          totalCacheSize -= entry.size
+        }
         decompressCache.delete(filePath)
       }
     }
@@ -135,22 +137,31 @@ export async function createFolderBasedFileSystemContentStorage(
     return undefined
   }
 
-  const noFailUnlink = async (path: string) => {
+  const noFailUnlink = async (path: string): Promise<boolean> => {
     try {
       await components.fs.unlink(path)
+      return true
     } catch (error) {
-      // Ignore these errors
+      return false
     }
   }
 
   const storeStream = async (id: string, stream: Readable): Promise<void> => {
-    await pipe(stream, components.fs.createWriteStream(await getFilePath(id)))
+    const filePath = await getFilePath(id)
+    try {
+      await pipe(stream, components.fs.createWriteStream(filePath))
+    } catch (err) {
+      await noFailUnlink(filePath)
+      throw err
+    }
   }
 
-  function removeCacheEntry(filePath: string) {
+  async function removeCacheEntry(filePath: string) {
     const entry = decompressCache.get(filePath)
     if (entry) {
-      totalCacheSize -= entry.size
+      if (await noFailUnlink(filePath)) {
+        totalCacheSize -= entry.size
+      }
       decompressCache.delete(filePath)
     }
   }
@@ -274,8 +285,9 @@ export async function createFolderBasedFileSystemContentStorage(
       }
       // Evict all cached files on shutdown to prevent disk leaks across restarts
       for (const [filePath, entry] of decompressCache) {
-        await noFailUnlink(filePath)
-        totalCacheSize -= entry.size
+        if (await noFailUnlink(filePath)) {
+          totalCacheSize -= entry.size
+        }
         decompressCache.delete(filePath)
       }
     },

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -159,13 +159,15 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  async function removeCacheEntry(filePath: string) {
+  async function removeCacheEntry(filePath: string): Promise<boolean> {
     const entry = decompressCache.get(filePath)
     if (entry) {
       await noFailUnlink(filePath)
       totalCacheSize -= entry.size
       decompressCache.delete(filePath)
+      return true
     }
+    return false
   }
 
   function touchCacheEntry(filePath: string) {
@@ -191,14 +193,14 @@ export async function createFolderBasedFileSystemContentStorage(
       // If range was requested but uncompressed file doesn't exist, fall back to
       // decompressing the gzip file, writing it to disk as a cache, and serving the range.
       if (!contentItem && range) {
-        const gzipItem = await retrieveWithEncoding(id, 'gzip')
-        if (gzipItem) {
-          const uncompressedPath = await getFilePath(id)
+        const uncompressedPath = await getFilePath(id)
 
-          // Wait for any in-flight decompression of the same file, or start one
-          let decompressPromise = inflightDecompressions.get(uncompressedPath)
-          const isOwner = !decompressPromise
-          if (!decompressPromise) {
+        // Wait for any in-flight decompression of the same file, or start one
+        let decompressPromise = inflightDecompressions.get(uncompressedPath)
+        const isOwner = !decompressPromise
+        if (!decompressPromise) {
+          const gzipItem = await retrieveWithEncoding(id, 'gzip')
+          if (gzipItem) {
             decompressPromise = (async () => {
               try {
                 await pipe(await gzipItem.asStream(), components.fs.createWriteStream(uncompressedPath))
@@ -214,6 +216,8 @@ export async function createFolderBasedFileSystemContentStorage(
             })()
             inflightDecompressions.set(uncompressedPath, decompressPromise)
           }
+        }
+        if (decompressPromise) {
           try {
             await decompressPromise
           } finally {
@@ -234,7 +238,8 @@ export async function createFolderBasedFileSystemContentStorage(
   }
 
   async function exist(id: string): Promise<boolean> {
-    return !!(await retrieve(id))
+    const filePath = await getFilePath(id)
+    return (await components.fs.existPath(filePath + '.gzip')) || (await components.fs.existPath(filePath))
   }
 
   const allFileIdsRec = async function* (folder: string, prefix?: string): AsyncIterable<string> {
@@ -281,6 +286,8 @@ export async function createFolderBasedFileSystemContentStorage(
         clearInterval(evictionTimer)
         evictionTimer = undefined
       }
+      // Wait for any inflight decompressions to finish before cleaning up
+      await Promise.allSettled(inflightDecompressions.values())
       // Evict all cached files on shutdown to prevent disk leaks across restarts
       for (const [filePath, entry] of decompressCache) {
         await noFailUnlink(filePath)
@@ -292,21 +299,24 @@ export async function createFolderBasedFileSystemContentStorage(
     retrieve,
     exist,
     async storeStreamAndCompress(id: string, stream: Readable): Promise<void> {
-      await removeCacheEntry(await getFilePath(id))
+      const filePath = await getFilePath(id)
+      await removeCacheEntry(filePath)
       await storeStream(id, stream)
-      if (await compressContentFile(await getFilePath(id))) {
+      if (await compressContentFile(filePath)) {
         // try to remove original file if present
         const contentItem = await retrieve(id)
         if (contentItem?.encoding) {
-          await noFailUnlink(await getFilePath(id))
+          await noFailUnlink(filePath)
         }
       }
     },
     async delete(ids: string[]): Promise<void> {
       for (const id of ids) {
         const filePath = await getFilePath(id)
-        await removeCacheEntry(filePath)
-        await noFailUnlink(filePath)
+        const wasCached = await removeCacheEntry(filePath)
+        if (!wasCached) {
+          await noFailUnlink(filePath)
+        }
         await noFailUnlink(filePath + '.gzip')
       }
     },

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -71,7 +71,8 @@ export async function createFolderBasedFileSystemContentStorage(
       return new SimpleContentItem(
         async () => components.fs.createReadStream(filePath, range),
         range ? range.end - range.start + 1 : stat.size,
-        encoding)
+        encoding
+      )
     }
 
     return undefined
@@ -89,18 +90,13 @@ export async function createFolderBasedFileSystemContentStorage(
     await pipe(stream, components.fs.createWriteStream(await getFilePath(id)))
   }
 
-  const retrieve = async (
-    id: string,
-    range?: { start: number; end: number }
-  ): Promise<ContentItem | undefined> => {
+  const retrieve = async (id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> => {
     try {
-      let contentItem: ContentItem | undefined = undefined;
+      let contentItem: ContentItem | undefined = undefined
 
-      if (!range)
-        contentItem = await retrieveWithEncoding(id, 'gzip')
+      if (!range) contentItem = await retrieveWithEncoding(id, 'gzip')
 
-      if (!contentItem)
-        contentItem = await retrieveWithEncoding(id, null, range)
+      if (!contentItem) contentItem = await retrieveWithEncoding(id, null, range)
 
       return contentItem
     } catch (error: any) {

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -103,6 +103,49 @@ export async function createFolderBasedFileSystemContentStorage(
       let contentItem: ContentItem | undefined = undefined
       if (!range) contentItem = await retrieveWithEncoding(id, 'gzip')
       if (!contentItem) contentItem = await retrieveWithEncoding(id, null, range)
+
+      // If range was requested but uncompressed file doesn't exist, fall back to
+      // decompressing the gzip file and extracting only the requested range.
+      // We stream-decompress, skip bytes before range.start, and collect bytes
+      // until range.end — only the range portion is buffered in memory.
+      if (!contentItem && range) {
+        const gzipItem = await retrieveWithEncoding(id, 'gzip')
+        if (gzipItem) {
+          if (range.start < 0 || range.start > range.end) {
+            throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
+          }
+          const decompressedStream = await gzipItem.asStream()
+          const chunks: Buffer[] = []
+          let offset = 0
+
+          await new Promise<void>((resolve, reject) => {
+            decompressedStream.on('error', reject)
+            decompressedStream.on('data', (chunk: Buffer) => {
+              const chunkStart = offset
+              const chunkEnd = offset + chunk.length - 1
+              offset += chunk.length
+
+              if (chunkEnd < range.start) return // before range, skip
+              if (chunkStart > range.end) {
+                decompressedStream.destroy() // past range, stop
+                return
+              }
+
+              const sliceStart = Math.max(0, range.start - chunkStart)
+              const sliceEnd = Math.min(chunk.length, range.end - chunkStart + 1)
+              chunks.push(chunk.subarray(sliceStart, sliceEnd))
+            })
+            decompressedStream.on('end', resolve)
+            decompressedStream.on('close', resolve)
+          })
+
+          const result = Buffer.concat(chunks)
+          if (result.length > 0) {
+            return SimpleContentItem.fromBuffer(result)
+          }
+        }
+      }
+
       return contentItem
     } catch (error: any) {
       if (error instanceof RangeError) throw error

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -74,8 +74,7 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  const evictionTimer = setInterval(evictCache, CACHE_EVICTION_INTERVAL)
-  evictionTimer.unref()
+  let evictionTimer: ReturnType<typeof setInterval> | undefined
 
   async function getFilePath(id: string): Promise<string> {
     // We are sharding the files using the first 4 digits of its sha1 hash, because it generates collisions
@@ -236,6 +235,17 @@ export async function createFolderBasedFileSystemContentStorage(
   }
 
   return {
+    async start(_startOptions: any) {
+      evictionTimer = setInterval(evictCache, CACHE_EVICTION_INTERVAL)
+      evictionTimer.unref()
+    },
+    async stop() {
+      if (evictionTimer) {
+        clearInterval(evictionTimer)
+        evictionTimer = undefined
+      }
+      await evictCache()
+    },
     storeStream,
     retrieve,
     exist,

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -3,15 +3,25 @@ import path from 'path'
 import { pipeline, Readable } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, ContentItem, FileInfo, IContentStorageComponent } from './types'
-import { SimpleContentItem } from './content-item'
+import { SimpleContentItem, streamToBuffer } from './content-item'
 import { compressContentFile } from './extras/compression'
 
 const pipe = promisify(pipeline)
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000
+const FIVE_MINUTES_IN_MS = 5 * 60 * 1000
+const ONE_GB_IN_BYTES = 1024 * 1024 * 1024
 
 /** @public */
 export type FolderStorageOptions = {
   /// by default FALSE, disables the sha1 prefix for all files. @see getFilePath
   disablePrefixHash: boolean
+  /** TTL in milliseconds for cached decompressed files. Default: 1 hour. */
+  decompressCacheTTL: number
+  /** Max total size in bytes for cached decompressed files. Default: 1GB. */
+  decompressCacheMaxSize: number
+  /** How often to run the eviction check in milliseconds. Default: 5 minutes. */
+  decompressCacheEvictionInterval: number
 }
 
 /**
@@ -32,6 +42,40 @@ export async function createFolderBasedFileSystemContentStorage(
   await components.fs.mkdir(root, { recursive: true })
 
   const USE_HASH_PREFIX = !(options?.disablePrefixHash ?? false)
+  const CACHE_TTL = options?.decompressCacheTTL ?? ONE_HOUR_IN_MS
+  const CACHE_MAX_SIZE = options?.decompressCacheMaxSize ?? ONE_GB_IN_BYTES
+  const CACHE_EVICTION_INTERVAL = options?.decompressCacheEvictionInterval ?? FIVE_MINUTES_IN_MS
+
+  // LRU cache tracker for decompressed gzip files written to disk
+  const decompressCache = new Map<string, { size: number; lastAccess: number }>()
+  let totalCacheSize = 0
+
+  async function evictCache() {
+    const now = Date.now()
+
+    // TTL eviction
+    for (const [filePath, entry] of decompressCache) {
+      if (now - entry.lastAccess > CACHE_TTL) {
+        await noFailUnlink(filePath)
+        totalCacheSize -= entry.size
+        decompressCache.delete(filePath)
+      }
+    }
+
+    // Size eviction (LRU)
+    if (totalCacheSize > CACHE_MAX_SIZE) {
+      const sorted = [...decompressCache.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess)
+      for (const [filePath, entry] of sorted) {
+        if (totalCacheSize <= CACHE_MAX_SIZE) break
+        await noFailUnlink(filePath)
+        totalCacheSize -= entry.size
+        decompressCache.delete(filePath)
+      }
+    }
+  }
+
+  const evictionTimer = setInterval(evictCache, CACHE_EVICTION_INTERVAL)
+  evictionTimer.unref()
 
   async function getFilePath(id: string): Promise<string> {
     // We are sharding the files using the first 4 digits of its sha1 hash, because it generates collisions
@@ -98,51 +142,54 @@ export async function createFolderBasedFileSystemContentStorage(
     await pipe(stream, components.fs.createWriteStream(await getFilePath(id)))
   }
 
+  function removeCacheEntry(filePath: string) {
+    const entry = decompressCache.get(filePath)
+    if (entry) {
+      totalCacheSize -= entry.size
+      decompressCache.delete(filePath)
+    }
+  }
+
+  function touchCacheEntry(filePath: string) {
+    const entry = decompressCache.get(filePath)
+    if (entry) {
+      entry.lastAccess = Date.now()
+    }
+  }
+
   const retrieve = async (id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> => {
     try {
       let contentItem: ContentItem | undefined = undefined
       if (!range) contentItem = await retrieveWithEncoding(id, 'gzip')
-      if (!contentItem) contentItem = await retrieveWithEncoding(id, null, range)
+      if (!contentItem) {
+        contentItem = await retrieveWithEncoding(id, null, range)
+        if (contentItem && range) {
+          // Update last access if this file is in the cache
+          touchCacheEntry(await getFilePath(id))
+        }
+      }
 
       // If range was requested but uncompressed file doesn't exist, fall back to
-      // decompressing the gzip file and extracting only the requested range.
-      // We stream-decompress, skip bytes before range.start, and collect bytes
-      // until range.end — only the range portion is buffered in memory.
+      // decompressing the gzip file, writing it to disk as a cache, and serving the range.
       if (!contentItem && range) {
         const gzipItem = await retrieveWithEncoding(id, 'gzip')
         if (gzipItem) {
           if (range.start < 0 || range.start > range.end) {
             throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
           }
-          const decompressedStream = await gzipItem.asStream()
-          const chunks: Buffer[] = []
-          let offset = 0
 
-          await new Promise<void>((resolve, reject) => {
-            decompressedStream.on('error', reject)
-            decompressedStream.on('data', (chunk: Buffer) => {
-              const chunkStart = offset
-              const chunkEnd = offset + chunk.length - 1
-              offset += chunk.length
+          // Decompress to disk
+          const uncompressedPath = await getFilePath(id)
+          const decompressed = await streamToBuffer(await gzipItem.asStream())
+          await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
 
-              if (chunkEnd < range.start) return // before range, skip
-              if (chunkStart > range.end) {
-                decompressedStream.destroy() // past range, stop
-                return
-              }
+          // Track in cache
+          const size = decompressed.length
+          decompressCache.set(uncompressedPath, { size, lastAccess: Date.now() })
+          totalCacheSize += size
 
-              const sliceStart = Math.max(0, range.start - chunkStart)
-              const sliceEnd = Math.min(chunk.length, range.end - chunkStart + 1)
-              chunks.push(chunk.subarray(sliceStart, sliceEnd))
-            })
-            decompressedStream.on('end', resolve)
-            decompressedStream.on('close', resolve)
-          })
-
-          const result = Buffer.concat(chunks)
-          if (result.length > 0) {
-            return SimpleContentItem.fromBuffer(result)
-          }
+          // Serve range from the cached uncompressed file
+          contentItem = await retrieveWithEncoding(id, null, range)
         }
       }
 
@@ -204,8 +251,10 @@ export async function createFolderBasedFileSystemContentStorage(
     },
     async delete(ids: string[]): Promise<void> {
       for (const id of ids) {
-        await noFailUnlink(await getFilePath(id))
-        await noFailUnlink((await getFilePath(id)) + '.gzip')
+        const filePath = await getFilePath(id)
+        removeCacheEntry(filePath)
+        await noFailUnlink(filePath)
+        await noFailUnlink(filePath + '.gzip')
       }
     },
     async existMultiple(cids: string[]): Promise<Map<string, boolean>> {

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { pipeline, Readable } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
-import { SimpleContentItem, streamToBuffer } from './content-item'
+import { SimpleContentItem } from './content-item'
 import { compressContentFile } from './extras/compression'
 
 const pipe = promisify(pipeline)
@@ -17,11 +17,11 @@ export type FolderStorageOptions = {
   /// by default FALSE, disables the sha1 prefix for all files. @see getFilePath
   disablePrefixHash: boolean
   /** TTL in milliseconds for cached decompressed files. Default: 1 hour. */
-  decompressCacheTTL: number
+  decompressCacheTTL?: number
   /** Max total size in bytes for cached decompressed files. Default: 1GB. */
-  decompressCacheMaxSize: number
+  decompressCacheMaxSize?: number
   /** How often to run the eviction check in milliseconds. Default: 5 minutes. */
-  decompressCacheEvictionInterval: number
+  decompressCacheEvictionInterval?: number
 }
 
 /**
@@ -53,15 +53,25 @@ export async function createFolderBasedFileSystemContentStorage(
   // Concurrency guard: prevents multiple simultaneous decompressions of the same file
   const inflightDecompressions = new Map<string, Promise<void>>()
 
+  let evicting = false
   async function evictCache() {
+    if (evicting) return
+    evicting = true
+    try {
+      await runEviction()
+    } finally {
+      evicting = false
+    }
+  }
+
+  async function runEviction() {
     const now = Date.now()
 
     // TTL eviction
     for (const [filePath, entry] of decompressCache) {
       if (now - entry.lastAccess > CACHE_TTL) {
-        if (await noFailUnlink(filePath)) {
-          totalCacheSize -= entry.size
-        }
+        await noFailUnlink(filePath)
+        totalCacheSize -= entry.size
         decompressCache.delete(filePath)
       }
     }
@@ -71,9 +81,8 @@ export async function createFolderBasedFileSystemContentStorage(
       const sorted = [...decompressCache.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess)
       for (const [filePath, entry] of sorted) {
         if (totalCacheSize <= CACHE_MAX_SIZE) break
-        if (await noFailUnlink(filePath)) {
-          totalCacheSize -= entry.size
-        }
+        await noFailUnlink(filePath)
+        totalCacheSize -= entry.size
         decompressCache.delete(filePath)
       }
     }
@@ -153,9 +162,8 @@ export async function createFolderBasedFileSystemContentStorage(
   async function removeCacheEntry(filePath: string) {
     const entry = decompressCache.get(filePath)
     if (entry) {
-      if (await noFailUnlink(filePath)) {
-        totalCacheSize -= entry.size
-      }
+      await noFailUnlink(filePath)
+      totalCacheSize -= entry.size
       decompressCache.delete(filePath)
     }
   }
@@ -168,6 +176,7 @@ export async function createFolderBasedFileSystemContentStorage(
   }
 
   const retrieve = async (id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> => {
+    if (range) validateRange(range)
     try {
       let contentItem: ContentItem | undefined = undefined
       if (!range) contentItem = await retrieveWithEncoding(id, 'gzip')
@@ -184,8 +193,6 @@ export async function createFolderBasedFileSystemContentStorage(
       if (!contentItem && range) {
         const gzipItem = await retrieveWithEncoding(id, 'gzip')
         if (gzipItem) {
-          validateRange(range)
-
           const uncompressedPath = await getFilePath(id)
 
           // Wait for any in-flight decompression of the same file, or start one
@@ -193,18 +200,17 @@ export async function createFolderBasedFileSystemContentStorage(
           const isOwner = !decompressPromise
           if (!decompressPromise) {
             decompressPromise = (async () => {
-              const decompressed = await streamToBuffer(await gzipItem.asStream())
               try {
-                await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
+                await pipe(await gzipItem.asStream(), components.fs.createWriteStream(uncompressedPath))
               } catch (err) {
                 // Remove partial file to prevent serving corrupt data
                 await noFailUnlink(uncompressedPath)
                 throw err
               }
 
-              const size = decompressed.length
-              decompressCache.set(uncompressedPath, { size, lastAccess: Date.now() })
-              totalCacheSize += size
+              const stat = await components.fs.stat(uncompressedPath)
+              decompressCache.set(uncompressedPath, { size: stat.size, lastAccess: Date.now() })
+              totalCacheSize += stat.size
             })()
             inflightDecompressions.set(uncompressedPath, decompressPromise)
           }
@@ -277,9 +283,8 @@ export async function createFolderBasedFileSystemContentStorage(
       }
       // Evict all cached files on shutdown to prevent disk leaks across restarts
       for (const [filePath, entry] of decompressCache) {
-        if (await noFailUnlink(filePath)) {
-          totalCacheSize -= entry.size
-        }
+        await noFailUnlink(filePath)
+        totalCacheSize -= entry.size
         decompressCache.delete(filePath)
       }
     },

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -295,7 +295,7 @@ export async function createFolderBasedFileSystemContentStorage(
     retrieve,
     exist,
     async storeStreamAndCompress(id: string, stream: Readable): Promise<void> {
-      removeCacheEntry(await getFilePath(id))
+      await removeCacheEntry(await getFilePath(id))
       await storeStream(id, stream)
       if (await compressContentFile(await getFilePath(id))) {
         // try to remove original file if present
@@ -308,7 +308,7 @@ export async function createFolderBasedFileSystemContentStorage(
     async delete(ids: string[]): Promise<void> {
       for (const id of ids) {
         const filePath = await getFilePath(id)
-        removeCacheEntry(filePath)
+        await removeCacheEntry(filePath)
         await noFailUnlink(filePath)
         await noFailUnlink(filePath + '.gzip')
       }

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -57,13 +57,21 @@ export async function createFolderBasedFileSystemContentStorage(
     return finalPath
   }
 
-  const retrieveWithEncoding = async (id: string, encoding: string | null): Promise<ContentItem | undefined> => {
+  const retrieveWithEncoding = async (
+    id: string,
+    encoding: string | null,
+    range?: { start: number; end: number }
+  ): Promise<ContentItem | undefined> => {
     const extension = encoding ? '.' + encoding : ''
     const filePath = (await getFilePath(id)) + extension
 
     if (await components.fs.existPath(filePath)) {
       const stat = await components.fs.stat(filePath)
-      return new SimpleContentItem(async () => components.fs.createReadStream(filePath), stat.size, encoding)
+
+      return new SimpleContentItem(
+        async () => components.fs.createReadStream(filePath, range),
+        range ? range.end - range.start + 1 : stat.size,
+        encoding)
     }
 
     return undefined
@@ -81,9 +89,20 @@ export async function createFolderBasedFileSystemContentStorage(
     await pipe(stream, components.fs.createWriteStream(await getFilePath(id)))
   }
 
-  const retrieve = async (id: string): Promise<ContentItem | undefined> => {
+  const retrieve = async (
+    id: string,
+    range?: { start: number; end: number }
+  ): Promise<ContentItem | undefined> => {
     try {
-      return (await retrieveWithEncoding(id, 'gzip')) || (await retrieveWithEncoding(id, null))
+      let contentItem: ContentItem | undefined = undefined;
+
+      if (!range)
+        contentItem = await retrieveWithEncoding(id, 'gzip')
+
+      if (!contentItem)
+        contentItem = await retrieveWithEncoding(id, null, range)
+
+      return contentItem
     } catch (error: any) {
       logger.error(error)
     }

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -68,11 +68,19 @@ export async function createFolderBasedFileSystemContentStorage(
     if (await components.fs.existPath(filePath)) {
       const stat = await components.fs.stat(filePath)
 
-      return new SimpleContentItem(
-        async () => components.fs.createReadStream(filePath, range),
-        range ? range.end - range.start + 1 : stat.size,
-        encoding
-      )
+      if (range) {
+        if (range.start < 0 || range.start > range.end) {
+          throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
+        }
+        const clampedEnd = Math.min(range.end, stat.size - 1)
+        return new SimpleContentItem(
+          async () => components.fs.createReadStream(filePath, { start: range.start, end: clampedEnd }),
+          clampedEnd - range.start + 1,
+          encoding
+        )
+      }
+
+      return new SimpleContentItem(async () => components.fs.createReadStream(filePath), stat.size, encoding)
     }
 
     return undefined
@@ -97,6 +105,7 @@ export async function createFolderBasedFileSystemContentStorage(
       if (!contentItem) contentItem = await retrieveWithEncoding(id, null, range)
       return contentItem
     } catch (error: any) {
+      if (error instanceof RangeError) throw error
       logger.error(error)
     }
     return undefined

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -119,6 +119,9 @@ export async function createFolderBasedFileSystemContentStorage(
           throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
         }
         const clampedEnd = Math.min(range.end, stat.size - 1)
+        if (range.start > clampedEnd) {
+          throw new RangeError(`Range start ${range.start} exceeds file size ${stat.size}`)
+        }
         return new SimpleContentItem(
           async () => components.fs.createReadStream(filePath, { start: range.start, end: clampedEnd }),
           clampedEnd - range.start + 1,
@@ -183,10 +186,10 @@ export async function createFolderBasedFileSystemContentStorage(
           const uncompressedPath = await getFilePath(id)
 
           // Wait for any in-flight decompression of the same file, or start one
-          if (inflightDecompressions.has(uncompressedPath)) {
-            await inflightDecompressions.get(uncompressedPath)
-          } else {
-            const decompressPromise = (async () => {
+          let decompressPromise = inflightDecompressions.get(uncompressedPath)
+          const isOwner = !decompressPromise
+          if (!decompressPromise) {
+            decompressPromise = (async () => {
               const decompressed = await streamToBuffer(await gzipItem.asStream())
               await pipe(Readable.from(decompressed), components.fs.createWriteStream(uncompressedPath))
 
@@ -195,11 +198,11 @@ export async function createFolderBasedFileSystemContentStorage(
               totalCacheSize += size
             })()
             inflightDecompressions.set(uncompressedPath, decompressPromise)
-            try {
-              await decompressPromise
-            } finally {
-              inflightDecompressions.delete(uncompressedPath)
-            }
+          }
+          try {
+            await decompressPromise
+          } finally {
+            if (isOwner) inflightDecompressions.delete(uncompressedPath)
           }
 
           // Serve range from the cached uncompressed file
@@ -225,7 +228,11 @@ export async function createFolderBasedFileSystemContentStorage(
       if (entry.isDirectory()) {
         yield* allFileIdsRec(path.resolve(folder, entry.name), prefix)
       } else if (!prefix || entry.name.startsWith(prefix)) {
-        yield entry.name.replace(/\.gzip/, '')
+        const baseName = entry.name.replace(/\.gzip$/, '')
+        // Skip cached uncompressed files when the .gzip version also exists
+        if (baseName !== entry.name || !(await components.fs.existPath(path.resolve(folder, baseName + '.gzip')))) {
+          yield baseName
+        }
       }
     }
   }
@@ -265,6 +272,7 @@ export async function createFolderBasedFileSystemContentStorage(
     retrieve,
     exist,
     async storeStreamAndCompress(id: string, stream: Readable): Promise<void> {
+      removeCacheEntry(await getFilePath(id))
       await storeStream(id, stream)
       if (await compressContentFile(await getFilePath(id))) {
         // try to remove original file if present

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto'
 import path from 'path'
 import { pipeline, Readable } from 'stream'
 import { promisify } from 'util'
-import { AppComponents, ContentItem, FileInfo, IContentStorageComponent } from './types'
+import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
 import { compressContentFile } from './extras/compression'
 
@@ -117,13 +117,7 @@ export async function createFolderBasedFileSystemContentStorage(
       const stat = await components.fs.stat(filePath)
 
       if (range) {
-        if (range.start < 0 || range.start > range.end) {
-          throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
-        }
-        const clampedEnd = Math.min(range.end, stat.size - 1)
-        if (range.start > clampedEnd) {
-          throw new RangeError(`Range start ${range.start} exceeds file size ${stat.size}`)
-        }
+        const clampedEnd = clampRange(range, stat.size)
         return new SimpleContentItem(
           async () => components.fs.createReadStream(filePath, { start: range.start, end: clampedEnd }),
           clampedEnd - range.start + 1,
@@ -190,9 +184,7 @@ export async function createFolderBasedFileSystemContentStorage(
       if (!contentItem && range) {
         const gzipItem = await retrieveWithEncoding(id, 'gzip')
         if (gzipItem) {
-          if (range.start < 0 || range.start > range.end) {
-            throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
-          }
+          validateRange(range)
 
           const uncompressedPath = await getFilePath(id)
 

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -34,6 +34,9 @@ export function createInMemoryStorage(): IContentStorageComponent {
           throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
         }
         const clampedEnd = Math.min(range.end, content.length - 1)
+        if (range.start > clampedEnd) {
+          throw new RangeError(`Range start ${range.start} exceeds content size ${content.length}`)
+        }
         return SimpleContentItem.fromBuffer(content.subarray(range.start, clampedEnd + 1))
       }
       return SimpleContentItem.fromBuffer(content)

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -26,9 +26,19 @@ export function createInMemoryStorage(): IContentStorageComponent {
     async delete(ids: string[]): Promise<void> {
       ids.forEach((id) => storage.delete(id))
     },
-    async retrieve(fileId: string): Promise<ContentItem | undefined> {
-      const content = storage.get(fileId)
-      return content ? SimpleContentItem.fromBuffer(content) : undefined
+    async retrieve(
+      fileId: string,
+      range?: { start: number; end: number }
+    ): Promise<ContentItem | undefined> {
+      let content = storage.get(fileId)
+
+      if (!content)
+        return undefined
+
+      if (range)
+        content = content.subarray(range.start, range.end + 1)
+
+      return SimpleContentItem.fromBuffer(content)
     },
     async existMultiple(fileIds: string[]): Promise<Map<string, boolean>> {
       return new Map(fileIds.map((fileId) => [fileId, storage.has(fileId)]))

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -27,9 +27,15 @@ export function createInMemoryStorage(): IContentStorageComponent {
       ids.forEach((id) => storage.delete(id))
     },
     async retrieve(fileId: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
-      let content = storage.get(fileId)
+      const content = storage.get(fileId)
       if (!content) return undefined
-      if (range) content = content.subarray(range.start, range.end + 1)
+      if (range) {
+        if (range.start < 0 || range.start > range.end) {
+          throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
+        }
+        const clampedEnd = Math.min(range.end, content.length - 1)
+        return SimpleContentItem.fromBuffer(content.subarray(range.start, clampedEnd + 1))
+      }
       return SimpleContentItem.fromBuffer(content)
     },
     async existMultiple(fileIds: string[]): Promise<Map<string, boolean>> {

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream'
-import { ContentItem, FileInfo, IContentStorageComponent } from './types'
+import { clampRange, ContentItem, FileInfo, IContentStorageComponent } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
 
 /**
@@ -30,13 +30,7 @@ export function createInMemoryStorage(): IContentStorageComponent {
       const content = storage.get(fileId)
       if (!content) return undefined
       if (range) {
-        if (range.start < 0 || range.start > range.end) {
-          throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
-        }
-        const clampedEnd = Math.min(range.end, content.length - 1)
-        if (range.start > clampedEnd) {
-          throw new RangeError(`Range start ${range.start} exceeds content size ${content.length}`)
-        }
+        const clampedEnd = clampRange(range, content.length)
         return SimpleContentItem.fromBuffer(content.subarray(range.start, clampedEnd + 1))
       }
       return SimpleContentItem.fromBuffer(content)

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -26,17 +26,12 @@ export function createInMemoryStorage(): IContentStorageComponent {
     async delete(ids: string[]): Promise<void> {
       ids.forEach((id) => storage.delete(id))
     },
-    async retrieve(
-      fileId: string,
-      range?: { start: number; end: number }
-    ): Promise<ContentItem | undefined> {
+    async retrieve(fileId: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
       let content = storage.get(fileId)
 
-      if (!content)
-        return undefined
+      if (!content) return undefined
 
-      if (range)
-        content = content.subarray(range.start, range.end + 1)
+      if (range) content = content.subarray(range.start, range.end + 1)
 
       return SimpleContentItem.fromBuffer(content)
     },

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -28,11 +28,8 @@ export function createInMemoryStorage(): IContentStorageComponent {
     },
     async retrieve(fileId: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
       let content = storage.get(fileId)
-
       if (!content) return undefined
-
       if (range) content = content.subarray(range.start, range.end + 1)
-
       return SimpleContentItem.fromBuffer(content)
     },
     async existMultiple(fileIds: string[]): Promise<Map<string, boolean>> {

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream'
-import { clampRange, ContentItem, FileInfo, IContentStorageComponent } from './types'
+import { clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
 
 /**
@@ -27,6 +27,7 @@ export function createInMemoryStorage(): IContentStorageComponent {
       ids.forEach((id) => storage.delete(id))
     },
     async retrieve(fileId: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
+      if (range) validateRange(range)
       const content = storage.get(fileId)
       if (!content) return undefined
       if (range) {

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -112,7 +112,11 @@ export async function createS3BasedFileSystemContentStorage(
 
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
-      const clampedEnd = range && obj.ContentLength ? Math.min(range.end, obj.ContentLength - 1) : range?.end
+      const clampedEnd = range && obj.ContentLength != null ? Math.min(range.end, obj.ContentLength - 1) : range?.end
+
+      if (range && clampedEnd !== undefined && range.start > clampedEnd) {
+        throw new RangeError(`Range start ${range.start} exceeds file size ${obj.ContentLength}`)
+      }
 
       return new SimpleContentItem(
         async () =>

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -106,7 +106,13 @@ export async function createS3BasedFileSystemContentStorage(
 
   async function retrieve(id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
     try {
+      if (range && (range.start < 0 || range.start > range.end)) {
+        throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
+      }
+
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
+
+      const clampedEnd = range && obj.ContentLength ? Math.min(range.end, obj.ContentLength - 1) : range?.end
 
       return new SimpleContentItem(
         async () =>
@@ -114,13 +120,14 @@ export async function createS3BasedFileSystemContentStorage(
             .getObject({
               Bucket,
               Key: getKey(id),
-              Range: range ? `bytes=${range.start}-${range.end}` : undefined
+              Range: range ? `bytes=${range.start}-${clampedEnd}` : undefined
             })
             .createReadStream(),
-        range ? range.end - range.start + 1 : obj.ContentLength || null,
+        range && clampedEnd !== undefined ? clampedEnd - range.start + 1 : obj.ContentLength || null,
         obj.ContentEncoding || null
       )
     } catch (error: any) {
+      if (error instanceof RangeError) throw error
       if (error.code !== 'NotFound') {
         logger.error(error)
       }

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -104,19 +104,19 @@ export async function createS3BasedFileSystemContentStorage(
       .promise()
   }
 
-  async function retrieve(
-    id: string,
-    range?: { start: number; end: number }
-  ): Promise<ContentItem | undefined> {
+  async function retrieve(id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
     try {
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
       return new SimpleContentItem(
-        async () => s3.getObject({
-          Bucket,
-          Key: getKey(id),
-          Range: range ? `bytes=${range.start}-${range.end}` : undefined
-        }).createReadStream(),
+        async () =>
+          s3
+            .getObject({
+              Bucket,
+              Key: getKey(id),
+              Range: range ? `bytes=${range.start}-${range.end}` : undefined
+            })
+            .createReadStream(),
         range ? range.end - range.start + 1 : obj.ContentLength || null,
         obj.ContentEncoding || null
       )

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -112,7 +112,7 @@ export async function createS3BasedFileSystemContentStorage(
 
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
-      const clampedEnd = range && obj.ContentLength != null ? Math.min(range.end, obj.ContentLength - 1) : range?.end
+      const clampedEnd = range && obj.ContentLength !== undefined && obj.ContentLength !== null ? Math.min(range.end, obj.ContentLength - 1) : range?.end
 
       if (range && clampedEnd !== undefined && range.start > clampedEnd) {
         throw new RangeError(`Range start ${range.start} exceeds file size ${obj.ContentLength}`)

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -112,7 +112,10 @@ export async function createS3BasedFileSystemContentStorage(
 
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
-      const clampedEnd = range && obj.ContentLength !== undefined && obj.ContentLength !== null ? Math.min(range.end, obj.ContentLength - 1) : range?.end
+      const clampedEnd =
+        range && obj.ContentLength !== undefined && obj.ContentLength !== null
+          ? Math.min(range.end, obj.ContentLength - 1)
+          : range?.end
 
       if (range && clampedEnd !== undefined && range.start > clampedEnd) {
         throw new RangeError(`Range start ${range.start} exceeds file size ${obj.ContentLength}`)

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -109,10 +109,8 @@ export async function createS3BasedFileSystemContentStorage(
     try {
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
-      const clampedEnd =
-        range && obj.ContentLength !== undefined && obj.ContentLength !== null
-          ? clampRange(range, obj.ContentLength)
-          : range?.end
+      const size = obj.ContentLength ?? null
+      const clampedEnd = range && size !== null ? clampRange(range, size) : undefined
 
       return new SimpleContentItem(
         async () =>
@@ -120,10 +118,10 @@ export async function createS3BasedFileSystemContentStorage(
             .getObject({
               Bucket,
               Key: getKey(id),
-              Range: range ? `bytes=${range.start}-${clampedEnd}` : undefined
+              Range: range ? `bytes=${range.start}-${clampedEnd ?? range.end}` : undefined
             })
             .createReadStream(),
-        range && clampedEnd !== undefined ? clampedEnd - range.start + 1 : obj.ContentLength ?? null,
+        range ? (clampedEnd !== undefined ? clampedEnd - range.start + 1 : null) : size,
         obj.ContentEncoding || null
       )
     } catch (error: any) {
@@ -182,7 +180,7 @@ export async function createS3BasedFileSystemContentStorage(
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
       return {
         encoding: obj.ContentEncoding || null,
-        size: obj.ContentLength || null
+        size: obj.ContentLength ?? null
       }
     } catch {
       return undefined

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -1,6 +1,6 @@
 import { S3 } from 'aws-sdk'
 import { Readable } from 'stream'
-import { AppComponents, ContentItem, FileInfo, IContentStorageComponent } from './types'
+import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem } from './content-item'
 import { ListObjectsV2Output } from 'aws-sdk/clients/s3'
 import { fromBuffer } from 'file-type'
@@ -106,20 +106,14 @@ export async function createS3BasedFileSystemContentStorage(
 
   async function retrieve(id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
     try {
-      if (range && (range.start < 0 || range.start > range.end)) {
-        throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
-      }
+      if (range) validateRange(range)
 
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
       const clampedEnd =
         range && obj.ContentLength !== undefined && obj.ContentLength !== null
-          ? Math.min(range.end, obj.ContentLength - 1)
+          ? clampRange(range, obj.ContentLength)
           : range?.end
-
-      if (range && clampedEnd !== undefined && range.start > clampedEnd) {
-        throw new RangeError(`Range start ${range.start} exceeds file size ${obj.ContentLength}`)
-      }
 
       return new SimpleContentItem(
         async () =>

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -105,9 +105,8 @@ export async function createS3BasedFileSystemContentStorage(
   }
 
   async function retrieve(id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
+    if (range) validateRange(range)
     try {
-      if (range) validateRange(range)
-
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
       const clampedEnd =
@@ -124,7 +123,7 @@ export async function createS3BasedFileSystemContentStorage(
               Range: range ? `bytes=${range.start}-${clampedEnd}` : undefined
             })
             .createReadStream(),
-        range && clampedEnd !== undefined ? clampedEnd - range.start + 1 : obj.ContentLength || null,
+        range && clampedEnd !== undefined ? clampedEnd - range.start + 1 : obj.ContentLength ?? null,
         obj.ContentEncoding || null
       )
     } catch (error: any) {

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -104,13 +104,20 @@ export async function createS3BasedFileSystemContentStorage(
       .promise()
   }
 
-  async function retrieve(id: string): Promise<ContentItem | undefined> {
+  async function retrieve(
+    id: string,
+    range?: { start: number; end: number }
+  ): Promise<ContentItem | undefined> {
     try {
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
 
       return new SimpleContentItem(
-        async () => s3.getObject({ Bucket, Key: getKey(id) }).createReadStream(),
-        obj.ContentLength || null,
+        async () => s3.getObject({
+          Bucket,
+          Key: getKey(id),
+          Range: range ? `bytes=${range.start}-${range.end}` : undefined
+        }).createReadStream(),
+        range ? range.end - range.start + 1 : obj.ContentLength || null,
         obj.ContentEncoding || null
       )
     } catch (error: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type IContentStorageComponent = {
   storeStream(fileId: string, content: Readable): Promise<void>
   storeStreamAndCompress(fileId: string, content: Readable): Promise<void>
   delete(fileIds: string[]): Promise<void>
-  retrieve(fileId: string): Promise<ContentItem | undefined>
+  retrieve(fileId: string, range?: { start: number; end: number }): Promise<ContentItem | undefined>
   fileInfo(fileId: string): Promise<FileInfo | undefined>
   fileInfoMultiple(fileIds: string[]): Promise<Map<string, FileInfo | undefined>>
   exist(fileId: string): Promise<boolean>

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,28 @@ export type FileInfo = {
 /**
  * @public
  */
+/**
+ * Validates that a range is well-formed (start >= 0 and start <= end).
+ */
+export function validateRange(range: { start: number; end: number }): void {
+  if (range.start < 0 || range.start > range.end) {
+    throw new RangeError(`Invalid range: start=${range.start}, end=${range.end}`)
+  }
+}
+
+/**
+ * Clamps range.end to the file size and validates that start is within bounds.
+ * Returns the clamped end value.
+ */
+export function clampRange(range: { start: number; end: number }, size: number): number {
+  validateRange(range)
+  const clampedEnd = Math.min(range.end, size - 1)
+  if (range.start > clampedEnd) {
+    throw new RangeError(`Range start ${range.start} exceeds size ${size}`)
+  }
+  return clampedEnd
+}
+
 export type ContentItem = FileInfo & {
   /**
    * Gets the readable stream, uncompressed if necessary.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream'
 import { IFileSystemComponent } from './fs/types'
-import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IBaseComponent, IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
 /**
  * @public
  */
@@ -13,7 +13,7 @@ export type AppComponents = {
 /**
  * @public
  */
-export type IContentStorageComponent = {
+export type IContentStorageComponent = IBaseComponent & {
   storeStream(fileId: string, content: Readable): Promise<void>
   storeStreamAndCompress(fileId: string, content: Readable): Promise<void>
   delete(fileIds: string[]): Promise<void>

--- a/test/behavior.spec.ts
+++ b/test/behavior.spec.ts
@@ -14,7 +14,7 @@ import { createLogComponent } from '@well-known-components/logger'
 import { FileSystemUtils as fsu } from './file-system-utils'
 import AWSMock from 'mock-aws-s3'
 
-const options: (undefined | Partial<FolderStorageOptions>)[] = [
+const options: (undefined | FolderStorageOptions)[] = [
   undefined,
   { disablePrefixHash: true },
   { disablePrefixHash: false }

--- a/test/behavior.spec.ts
+++ b/test/behavior.spec.ts
@@ -14,7 +14,7 @@ import { createLogComponent } from '@well-known-components/logger'
 import { FileSystemUtils as fsu } from './file-system-utils'
 import AWSMock from 'mock-aws-s3'
 
-const options: (undefined | FolderStorageOptions)[] = [
+const options: (undefined | Partial<FolderStorageOptions>)[] = [
   undefined,
   { disablePrefixHash: true },
   { disablePrefixHash: false }

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -30,7 +30,8 @@ describe('fileSystemContentStorage', () => {
     filePath2 = path.join(tmpRootDir, 'ea6c', id2)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await fileSystemContentStorage.stop?.()
     rmSync(tmpRootDir, { recursive: true, force: false })
   })
 
@@ -235,19 +236,24 @@ describe('fileSystemContentStorage', () => {
         tmpDir,
         { decompressCacheTTL: shortTTL, decompressCacheEvictionInterval: shortEviction }
       )
+      await storage.start?.({} as any)
       const cachedFilePath = path.join(tmpDir, '9584', id)
 
-      const data = Buffer.from(new Uint8Array(100).fill(0))
-      await storage.storeStreamAndCompress(id, bufferToStream(data))
-      await storage.retrieve(id, { start: 0, end: 9 })
-      expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+      try {
+        const data = Buffer.from(new Uint8Array(100).fill(0))
+        await storage.storeStreamAndCompress(id, bufferToStream(data))
+        await storage.retrieve(id, { start: 0, end: 9 })
+        expect(await fs.existPath(cachedFilePath)).toBeTruthy()
 
-      // Wait for TTL + eviction interval to trigger cleanup
-      await new Promise((r) => setTimeout(r, shortTTL + shortEviction + 50))
+        // Wait for TTL + eviction interval to trigger cleanup
+        await new Promise((r) => setTimeout(r, shortTTL + shortEviction + 50))
 
-      expect(await fs.existPath(cachedFilePath)).toBeFalsy()
-      expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
-      rmSync(tmpDir, { recursive: true, force: true })
+        expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+        expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
+      } finally {
+        await storage.stop?.()
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
     })
 
     it(`When the cache exceeds max size, then LRU files are evicted`, async () => {
@@ -257,32 +263,37 @@ describe('fileSystemContentStorage', () => {
         tmpDir,
         { decompressCacheMaxSize: 150, decompressCacheEvictionInterval: 30 }
       )
+      await storage.start?.({} as any)
       const cachedFilePath1 = path.join(tmpDir, '9584', id)
       const cachedFilePath2 = path.join(tmpDir, 'ea6c', id2)
 
-      // Store two 100-byte files as gzip-only
-      const data = Buffer.from(new Uint8Array(100).fill(0))
-      await storage.storeStreamAndCompress(id, bufferToStream(data))
-      await storage.storeStreamAndCompress(id2, bufferToStream(Buffer.from(new Uint8Array(100).fill(1))))
+      try {
+        // Store two 100-byte files as gzip-only
+        const data = Buffer.from(new Uint8Array(100).fill(0))
+        await storage.storeStreamAndCompress(id, bufferToStream(data))
+        await storage.storeStreamAndCompress(id2, bufferToStream(Buffer.from(new Uint8Array(100).fill(1))))
 
-      // Trigger cache for first file
-      await storage.retrieve(id, { start: 0, end: 9 })
-      expect(await fs.existPath(cachedFilePath1)).toBeTruthy()
+        // Trigger cache for first file
+        await storage.retrieve(id, { start: 0, end: 9 })
+        expect(await fs.existPath(cachedFilePath1)).toBeTruthy()
 
-      // Small delay so id2 has a newer lastAccess
-      await new Promise((r) => setTimeout(r, 10))
+        // Small delay so id2 has a newer lastAccess
+        await new Promise((r) => setTimeout(r, 10))
 
-      // Trigger cache for second file — total cache now exceeds 150 bytes
-      await storage.retrieve(id2, { start: 0, end: 9 })
-      expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
+        // Trigger cache for second file — total cache now exceeds 150 bytes
+        await storage.retrieve(id2, { start: 0, end: 9 })
+        expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
 
-      // Wait for eviction interval to run
-      await new Promise((r) => setTimeout(r, 80))
+        // Wait for eviction interval to run
+        await new Promise((r) => setTimeout(r, 80))
 
-      // LRU file (id, accessed first) should be evicted, id2 should remain
-      expect(await fs.existPath(cachedFilePath1)).toBeFalsy()
-      expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
-      rmSync(tmpDir, { recursive: true, force: true })
+        // LRU file (id, accessed first) should be evicted, id2 should remain
+        expect(await fs.existPath(cachedFilePath1)).toBeFalsy()
+        expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
+      } finally {
+        await storage.stop?.()
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
     })
   })
 

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -376,12 +376,12 @@ describe('fileSystemContentStorage', () => {
       }
     })
 
-    it(`When stop() is called, then expired cached files are evicted`, async () => {
+    it(`When stop() is called, then all cached files are evicted regardless of TTL`, async () => {
       const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
       const storage = await createFolderBasedFileSystemContentStorage(
         { fs, logs: await createLogComponent({}) },
         tmpDir,
-        { decompressCacheTTL: 60000, decompressCacheEvictionInterval: 999999 }
+        { decompressCacheTTL: 999999, decompressCacheEvictionInterval: 999999 }
       )
       const cachedFilePath = path.join(tmpDir, '9584', id)
 
@@ -391,10 +391,7 @@ describe('fileSystemContentStorage', () => {
         await storage.retrieve(id, { start: 0, end: 9 })
         expect(await fs.existPath(cachedFilePath)).toBeTruthy()
 
-        // Advance past TTL (but eviction interval is very long, so timer won't fire)
-        jest.advanceTimersByTime(60001)
-
-        // stop() should run a final eviction pass
+        // stop() should evict all cached files even though TTL hasn't expired
         await storage.stop?.()
         expect(await fs.existPath(cachedFilePath)).toBeFalsy()
         expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -173,6 +173,11 @@ describe('fileSystemContentStorage', () => {
     await expect(fileSystemContentStorage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
   })
 
+  it(`When a range with start past end of file is requested, then it throws a RangeError`, async () => {
+    await fileSystemContentStorage.storeStream(id, bufferToStream(content))
+    await expect(fileSystemContentStorage.retrieve(id, { start: 10, end: 20 })).rejects.toThrow(RangeError)
+  })
+
   it(`When a range is requested on a non-existent file, then it returns undefined`, async () => {
     const item = await fileSystemContentStorage.retrieve('non-existent-id', { start: 0, end: 4 })
     expect(item).toBeUndefined()
@@ -255,6 +260,39 @@ describe('fileSystemContentStorage', () => {
     expect(await streamToBuffer(await item1!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
     expect(await streamToBuffer(await item2!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
     expect(await fs.existPath(filePath)).toBeTruthy()
+  })
+
+  it(`When a gzip-only file is cached, then allFileIds does not yield duplicates`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+    await fileSystemContentStorage.storeStream(id2, bufferToStream(content2))
+
+    // Trigger cache — both file and file.gzip now exist for id
+    await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
+    expect(await fs.existPath(filePath)).toBeTruthy()
+    expect(await fs.existPath(filePath + '.gzip')).toBeTruthy()
+
+    const seenIds: string[] = []
+    for await (const fileId of fileSystemContentStorage.allFileIds()) seenIds.push(fileId)
+    const idOccurrences = seenIds.filter((x) => x === id)
+    expect(idOccurrences.length).toBe(1)
+  })
+
+  it(`When storeStreamAndCompress is called after a cached decompression, then the cache entry is cleared`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    // Trigger cache
+    await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
+    expect(await fs.existPath(filePath)).toBeTruthy()
+
+    // Re-store and compress — should clear the cache entry
+    const newData = Buffer.from(new Uint8Array(200).fill(1))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(newData))
+
+    // The cached uncompressed file should be gone (deleted by storeStreamAndCompress)
+    const compressedFile = await fileSystemContentStorage.retrieve(id)
+    expect(compressedFile).toBeDefined()
   })
 
   describe('decompression cache eviction', () => {

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -320,11 +320,8 @@ describe('fileSystemContentStorage', () => {
         await storage.retrieve(id, { start: 0, end: 9 })
         expect(await fs.existPath(cachedFilePath)).toBeTruthy()
 
-        // Advance past TTL + eviction interval
-        jest.advanceTimersByTime(60000 + 30000)
-        // Allow the async eviction to complete
-        await Promise.resolve()
-        await Promise.resolve()
+        // Advance past TTL + eviction interval and flush async work
+        await jest.advanceTimersByTimeAsync(60000 + 30000)
 
         expect(await fs.existPath(cachedFilePath)).toBeFalsy()
         expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
@@ -362,10 +359,8 @@ describe('fileSystemContentStorage', () => {
         await storage.retrieve(id2, { start: 0, end: 9 })
         expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
 
-        // Advance past eviction interval
-        jest.advanceTimersByTime(30000)
-        await Promise.resolve()
-        await Promise.resolve()
+        // Advance past eviction interval and flush async work
+        await jest.advanceTimersByTimeAsync(30000)
 
         // LRU file (id, accessed first) should be evicted, id2 should remain
         expect(await fs.existPath(cachedFilePath1)).toBeFalsy()

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -181,13 +181,14 @@ describe('fileSystemContentStorage', () => {
     expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('Hello'))
   })
 
-  it(`When content is stored compressed (gzip only), then a range retrieve returns undefined`, async () => {
+  it(`When content is stored compressed (gzip only), then a range retrieve decompresses and serves the range`, async () => {
     const data = Buffer.from(new Uint8Array(100).fill(0))
     await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
 
-    // The original uncompressed file was deleted, and range requests skip gzip
     const item = await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
-    expect(item).toBeUndefined()
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(10)
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
   })
 
   it(`When content is stored, then we can check file info`, async function () {

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -173,6 +173,21 @@ describe('fileSystemContentStorage', () => {
     await expect(fileSystemContentStorage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
   })
 
+  it(`When a range is requested on a non-existent file, then it returns undefined`, async () => {
+    const item = await fileSystemContentStorage.retrieve('non-existent-id', { start: 0, end: 4 })
+    expect(item).toBeUndefined()
+  })
+
+  it(`When a single-byte range is requested, then it returns that byte`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await fileSystemContentStorage.storeStream(id, bufferToStream(data))
+
+    const item = await fileSystemContentStorage.retrieve(id, { start: 4, end: 4 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(1)
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('o'))
+  })
+
   it(`When content is stored with bad compression ratio, then a range can be retrieved from the uncompressed file`, async () => {
     await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(Buffer.from('Hello, World!')))
 
@@ -226,15 +241,37 @@ describe('fileSystemContentStorage', () => {
     expect(await fs.existPath(filePath + '.gzip')).toBeFalsy()
   })
 
+  it(`When concurrent range requests hit the same gzip-only file, then only one decompression occurs`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    const [item1, item2] = await Promise.all([
+      fileSystemContentStorage.retrieve(id, { start: 0, end: 9 }),
+      fileSystemContentStorage.retrieve(id, { start: 50, end: 59 })
+    ])
+
+    expect(item1).toBeDefined()
+    expect(item2).toBeDefined()
+    expect(await streamToBuffer(await item1!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
+    expect(await streamToBuffer(await item2!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
+    expect(await fs.existPath(filePath)).toBeTruthy()
+  })
+
   describe('decompression cache eviction', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
     it(`When the cache TTL expires, then the cached uncompressed file is cleaned up`, async () => {
-      const shortTTL = 50 // 50ms
-      const shortEviction = 30 // 30ms
       const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
       const storage = await createFolderBasedFileSystemContentStorage(
         { fs, logs: await createLogComponent({}) },
         tmpDir,
-        { decompressCacheTTL: shortTTL, decompressCacheEvictionInterval: shortEviction }
+        { decompressCacheTTL: 60000, decompressCacheEvictionInterval: 30000 }
       )
       await storage.start?.({} as any)
       const cachedFilePath = path.join(tmpDir, '9584', id)
@@ -245,8 +282,11 @@ describe('fileSystemContentStorage', () => {
         await storage.retrieve(id, { start: 0, end: 9 })
         expect(await fs.existPath(cachedFilePath)).toBeTruthy()
 
-        // Wait for TTL + eviction interval to trigger cleanup
-        await new Promise((r) => setTimeout(r, shortTTL + shortEviction + 50))
+        // Advance past TTL + eviction interval
+        jest.advanceTimersByTime(60000 + 30000)
+        // Allow the async eviction to complete
+        await Promise.resolve()
+        await Promise.resolve()
 
         expect(await fs.existPath(cachedFilePath)).toBeFalsy()
         expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
@@ -261,7 +301,7 @@ describe('fileSystemContentStorage', () => {
       const storage = await createFolderBasedFileSystemContentStorage(
         { fs, logs: await createLogComponent({}) },
         tmpDir,
-        { decompressCacheMaxSize: 150, decompressCacheEvictionInterval: 30 }
+        { decompressCacheMaxSize: 150, decompressCacheEvictionInterval: 30000 }
       )
       await storage.start?.({} as any)
       const cachedFilePath1 = path.join(tmpDir, '9584', id)
@@ -277,21 +317,50 @@ describe('fileSystemContentStorage', () => {
         await storage.retrieve(id, { start: 0, end: 9 })
         expect(await fs.existPath(cachedFilePath1)).toBeTruthy()
 
-        // Small delay so id2 has a newer lastAccess
-        await new Promise((r) => setTimeout(r, 10))
+        // Advance time so id2 has a newer lastAccess
+        jest.advanceTimersByTime(1000)
 
         // Trigger cache for second file — total cache now exceeds 150 bytes
         await storage.retrieve(id2, { start: 0, end: 9 })
         expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
 
-        // Wait for eviction interval to run
-        await new Promise((r) => setTimeout(r, 80))
+        // Advance past eviction interval
+        jest.advanceTimersByTime(30000)
+        await Promise.resolve()
+        await Promise.resolve()
 
         // LRU file (id, accessed first) should be evicted, id2 should remain
         expect(await fs.existPath(cachedFilePath1)).toBeFalsy()
         expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
       } finally {
         await storage.stop?.()
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it(`When stop() is called, then expired cached files are evicted`, async () => {
+      const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        tmpDir,
+        { decompressCacheTTL: 60000, decompressCacheEvictionInterval: 999999 }
+      )
+      const cachedFilePath = path.join(tmpDir, '9584', id)
+
+      try {
+        const data = Buffer.from(new Uint8Array(100).fill(0))
+        await storage.storeStreamAndCompress(id, bufferToStream(data))
+        await storage.retrieve(id, { start: 0, end: 9 })
+        expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+
+        // Advance past TTL (but eviction interval is very long, so timer won't fire)
+        jest.advanceTimersByTime(60001)
+
+        // stop() should run a final eviction pass
+        await storage.stop?.()
+        expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+        expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
+      } finally {
         rmSync(tmpDir, { recursive: true, force: true })
       }
     })

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -191,6 +191,101 @@ describe('fileSystemContentStorage', () => {
     expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
   })
 
+  it(`When a gzip-only file is range-requested, then the uncompressed file is cached to disk`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    expect(await fs.existPath(filePath)).toBeFalsy()
+    await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
+    expect(await fs.existPath(filePath)).toBeTruthy()
+  })
+
+  it(`When a gzip-only file is range-requested twice, then the second request reads from the cached file`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    const item1 = await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
+    expect(await streamToBuffer(await item1!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
+
+    const item2 = await fileSystemContentStorage.retrieve(id, { start: 50, end: 59 })
+    expect(item2).toBeDefined()
+    expect(item2!.size).toBe(10)
+    expect(await streamToBuffer(await item2!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
+  })
+
+  it(`When a cached file is deleted via storage.delete(), then it is removed from the cache`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
+    expect(await fs.existPath(filePath)).toBeTruthy()
+
+    await fileSystemContentStorage.delete([id])
+    expect(await fs.existPath(filePath)).toBeFalsy()
+    expect(await fs.existPath(filePath + '.gzip')).toBeFalsy()
+  })
+
+  describe('decompression cache eviction', () => {
+    it(`When the cache TTL expires, then the cached uncompressed file is cleaned up`, async () => {
+      const shortTTL = 50 // 50ms
+      const shortEviction = 30 // 30ms
+      const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        tmpDir,
+        { decompressCacheTTL: shortTTL, decompressCacheEvictionInterval: shortEviction }
+      )
+      const cachedFilePath = path.join(tmpDir, '9584', id)
+
+      const data = Buffer.from(new Uint8Array(100).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+      await storage.retrieve(id, { start: 0, end: 9 })
+      expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+
+      // Wait for TTL + eviction interval to trigger cleanup
+      await new Promise((r) => setTimeout(r, shortTTL + shortEviction + 50))
+
+      expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+      expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
+      rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it(`When the cache exceeds max size, then LRU files are evicted`, async () => {
+      const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        tmpDir,
+        { decompressCacheMaxSize: 150, decompressCacheEvictionInterval: 30 }
+      )
+      const cachedFilePath1 = path.join(tmpDir, '9584', id)
+      const cachedFilePath2 = path.join(tmpDir, 'ea6c', id2)
+
+      // Store two 100-byte files as gzip-only
+      const data = Buffer.from(new Uint8Array(100).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+      await storage.storeStreamAndCompress(id2, bufferToStream(Buffer.from(new Uint8Array(100).fill(1))))
+
+      // Trigger cache for first file
+      await storage.retrieve(id, { start: 0, end: 9 })
+      expect(await fs.existPath(cachedFilePath1)).toBeTruthy()
+
+      // Small delay so id2 has a newer lastAccess
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Trigger cache for second file — total cache now exceeds 150 bytes
+      await storage.retrieve(id2, { start: 0, end: 9 })
+      expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
+
+      // Wait for eviction interval to run
+      await new Promise((r) => setTimeout(r, 80))
+
+      // LRU file (id, accessed first) should be evicted, id2 should remain
+      expect(await fs.existPath(cachedFilePath1)).toBeFalsy()
+      expect(await fs.existPath(cachedFilePath2)).toBeTruthy()
+      rmSync(tmpDir, { recursive: true, force: true })
+    })
+  })
+
   it(`When content is stored, then we can check file info`, async function () {
     await fileSystemContentStorage.storeStream(id, bufferToStream(content))
     await fileSystemContentStorage.storeStream(id2, bufferToStream(content2))

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'fs'
+import { createHash } from 'crypto'
+import { mkdtempSync, promises as nodeFs, rmSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import { createFolderBasedFileSystemContentStorage, createFsComponent, IContentStorageComponent } from '../src'
@@ -371,6 +372,41 @@ describe('fileSystemContentStorage', () => {
       }
     })
 
+    it(`When the cache is evicted by TTL, then a subsequent range request re-decompresses successfully`, async () => {
+      const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        tmpDir,
+        { decompressCacheTTL: 60000, decompressCacheEvictionInterval: 30000 }
+      )
+      await storage.start?.({} as any)
+      const cachedFilePath = path.join(tmpDir, '9584', id)
+
+      try {
+        const data = Buffer.from(new Uint8Array(100).fill(0))
+        await storage.storeStreamAndCompress(id, bufferToStream(data))
+
+        // First range request — triggers decompression and cache
+        const item1 = await storage.retrieve(id, { start: 0, end: 9 })
+        expect(item1).toBeDefined()
+        expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+
+        // Advance past TTL + eviction interval to evict
+        await jest.advanceTimersByTimeAsync(60000 + 30000)
+        expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+
+        // Second range request — should re-decompress and serve correctly
+        const item2 = await storage.retrieve(id, { start: 50, end: 59 })
+        expect(item2).toBeDefined()
+        expect(item2!.size).toBe(10)
+        expect(await streamToBuffer(await item2!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
+        expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+      } finally {
+        await storage.stop?.()
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
     it(`When stop() is called, then all cached files are evicted regardless of TTL`, async () => {
       const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
       const storage = await createFolderBasedFileSystemContentStorage(
@@ -394,6 +430,129 @@ describe('fileSystemContentStorage', () => {
         rmSync(tmpDir, { recursive: true, force: true })
       }
     })
+  })
+
+  it(`When decompression fails due to a corrupt gzip file, then the partial file is cleaned up and retrieve returns undefined`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-corrupt-'))
+    const storage = await createFolderBasedFileSystemContentStorage({ fs, logs: await createLogComponent({}) }, tmpDir)
+    const corruptId = 'corrupt-file'
+    // sha1('corrupt-file') = first 4 chars
+    const hash = createHash('sha1').update(corruptId).digest('hex').substring(0, 4)
+    const gzipPath = path.join(tmpDir, hash, corruptId + '.gzip')
+    const uncompressedPath = path.join(tmpDir, hash, corruptId)
+
+    try {
+      // Write garbage data as a .gzip file to simulate corruption
+      await fs.mkdir(path.join(tmpDir, hash), { recursive: true })
+      await nodeFs.writeFile(gzipPath, Buffer.from('this is not valid gzip data'))
+
+      // Range request should trigger decompression which fails
+      const item = await storage.retrieve(corruptId, { start: 0, end: 4 })
+      expect(item).toBeUndefined()
+
+      // The partial uncompressed file should have been cleaned up
+      expect(await fs.existPath(uncompressedPath)).toBeFalsy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it(`When content is stored compressed (gzip only), then exist returns true`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+    // Verify only .gzip exists on disk
+    expect(await fs.existPath(filePath)).toBeFalsy()
+    expect(await fs.existPath(filePath + '.gzip')).toBeTruthy()
+
+    expect(await fileSystemContentStorage.exist(id)).toBe(true)
+  })
+
+  it(`When content does not exist, then exist returns false`, async () => {
+    expect(await fileSystemContentStorage.exist('non-existent-id')).toBe(false)
+  })
+
+  it(`When multiple content is stored, then existMultiple returns correct results`, async () => {
+    await fileSystemContentStorage.storeStream(id, bufferToStream(content))
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id2, bufferToStream(data))
+
+    const result = await fileSystemContentStorage.existMultiple([id, id2, 'non-existent'])
+    expect(result.get(id)).toBe(true)
+    expect(result.get(id2)).toBe(true)
+    expect(result.get('non-existent')).toBe(false)
+  })
+
+  it(`When content is stored compressed (gzip only), then fileInfo returns compressed encoding and size`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    const info = await fileSystemContentStorage.fileInfo(id)
+    expect(info).toBeDefined()
+    expect(info!.encoding).toBe('gzip')
+    expect(info!.size).toBeDefined()
+    expect(info!.size).toBeGreaterThan(0)
+    expect(info!.size).toBeLessThan(100)
+  })
+
+  it(`When a cached file is accessed via range, then its lastAccess is updated and it survives LRU eviction`, async () => {
+    jest.useFakeTimers()
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-touch-'))
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs, logs: await createLogComponent({}) },
+      tmpDir,
+      { decompressCacheMaxSize: 150, decompressCacheEvictionInterval: 30000 }
+    )
+    await storage.start?.({} as any)
+    const cachedFilePath1 = path.join(tmpDir, '9584', id)
+    const cachedFilePath2 = path.join(tmpDir, 'ea6c', id2)
+
+    try {
+      const data = Buffer.from(new Uint8Array(100).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+      await storage.storeStreamAndCompress(id2, bufferToStream(Buffer.from(new Uint8Array(100).fill(1))))
+
+      // Trigger cache for both files
+      await storage.retrieve(id, { start: 0, end: 9 })
+      jest.advanceTimersByTime(1000)
+      await storage.retrieve(id2, { start: 0, end: 9 })
+
+      // Now touch id (the older one) so it becomes most-recently-accessed
+      jest.advanceTimersByTime(1000)
+      await storage.retrieve(id, { start: 0, end: 9 })
+
+      // Advance past eviction interval
+      await jest.advanceTimersByTimeAsync(30000)
+
+      // id2 (least recently accessed) should be evicted, id should remain
+      expect(await fs.existPath(cachedFilePath1)).toBeTruthy()
+      expect(await fs.existPath(cachedFilePath2)).toBeFalsy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+      jest.useRealTimers()
+    }
+  })
+
+  it(`When start() is not called, then range requests and caching still work`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-nostart-'))
+    const storage = await createFolderBasedFileSystemContentStorage({ fs, logs: await createLogComponent({}) }, tmpDir)
+    // Intentionally do NOT call storage.start()
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    try {
+      const data = Buffer.from(new Uint8Array(100).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+
+      const item = await storage.retrieve(id, { start: 0, end: 9 })
+      expect(item).toBeDefined()
+      expect(item!.size).toBe(10)
+      expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from(new Uint8Array(10).fill(0)))
+      expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 
   it(`When content is stored, then we can check file info`, async function () {

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -135,6 +135,61 @@ describe('fileSystemContentStorage', () => {
     await check(undefined as any, ['another-id', 'some-id'])
   })
 
+  it(`When content is stored, then a range can be retrieved`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await fileSystemContentStorage.storeStream(id, bufferToStream(data))
+
+    const item = await fileSystemContentStorage.retrieve(id, { start: 0, end: 4 })
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('Hello'))
+    expect(item!.size).toBe(5)
+  })
+
+  it(`When content is stored, then a range in the middle can be retrieved`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await fileSystemContentStorage.storeStream(id, bufferToStream(data))
+
+    const item = await fileSystemContentStorage.retrieve(id, { start: 7, end: 11 })
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('World'))
+    expect(item!.size).toBe(5)
+  })
+
+  it(`When a range with end beyond file size is requested, then it clamps to file size`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await fileSystemContentStorage.storeStream(id, bufferToStream(data))
+
+    const item = await fileSystemContentStorage.retrieve(id, { start: 7, end: 999 })
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('World!'))
+    expect(item!.size).toBe(6)
+  })
+
+  it(`When a range with start > end is requested, then it throws a RangeError`, async () => {
+    await fileSystemContentStorage.storeStream(id, bufferToStream(content))
+    await expect(fileSystemContentStorage.retrieve(id, { start: 5, end: 2 })).rejects.toThrow(RangeError)
+  })
+
+  it(`When a range with negative start is requested, then it throws a RangeError`, async () => {
+    await fileSystemContentStorage.storeStream(id, bufferToStream(content))
+    await expect(fileSystemContentStorage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
+  })
+
+  it(`When content is stored with bad compression ratio, then a range can be retrieved from the uncompressed file`, async () => {
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(Buffer.from('Hello, World!')))
+
+    const item = await fileSystemContentStorage.retrieve(id, { start: 0, end: 4 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(5)
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('Hello'))
+  })
+
+  it(`When content is stored compressed (gzip only), then a range retrieve returns undefined`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    // The original uncompressed file was deleted, and range requests skip gzip
+    const item = await fileSystemContentStorage.retrieve(id, { start: 0, end: 9 })
+    expect(item).toBeUndefined()
+  })
+
   it(`When content is stored, then we can check file info`, async function () {
     await fileSystemContentStorage.storeStream(id, bufferToStream(content))
     await fileSystemContentStorage.storeStream(id2, bufferToStream(content2))

--- a/test/in-memory-storage-component.spec.ts
+++ b/test/in-memory-storage-component.spec.ts
@@ -176,4 +176,14 @@ describe('storage mock', () => {
     expect(exists.get(id)).toEqual({ encoding: null, size: 3 })
     expect(await storage.fileInfo(id)).toEqual({ encoding: null, size: 3 })
   })
+
+  it(`When multiple files exist, then fileInfoMultiple returns correct results for existing and non-existing keys`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await storage.storeStream(id2, bufferToStream(content2))
+
+    const result = await storage.fileInfoMultiple([id, id2, 'non-existent'])
+    expect(result.get(id)).toEqual({ encoding: null, size: 3 })
+    expect(result.get(id2)).toEqual({ encoding: null, size: 3 })
+    expect(result.get('non-existent')).toBeUndefined()
+  })
 })

--- a/test/in-memory-storage-component.spec.ts
+++ b/test/in-memory-storage-component.spec.ts
@@ -86,6 +86,43 @@ describe('storage mock', () => {
     expect(retrievedContent?.encoding).toBeUndefined()
   })
 
+  it(`When content is stored, then a range can be retrieved`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 0, end: 4 })
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('Hello'))
+    expect(item!.size).toBe(5)
+  })
+
+  it(`When content is stored, then a range in the middle can be retrieved`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 7, end: 11 })
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('World'))
+    expect(item!.size).toBe(5)
+  })
+
+  it(`When a range with end beyond file size is requested, then it clamps to file size`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 7, end: 999 })
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('World!'))
+    expect(item!.size).toBe(6)
+  })
+
+  it(`When a range with start > end is requested, then it throws a RangeError`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await expect(storage.retrieve(id, { start: 5, end: 2 })).rejects.toThrow(RangeError)
+  })
+
+  it(`When a range with negative start is requested, then it throws a RangeError`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await expect(storage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
+  })
+
   async function retrieveAndExpectStoredContentToBe(idToRetrieve: string, expectedContent: Buffer) {
     const retrievedContent = await storage.retrieve(idToRetrieve)
     expect(await streamToBuffer(await retrievedContent!.asStream())).toEqual(expectedContent)

--- a/test/in-memory-storage-component.spec.ts
+++ b/test/in-memory-storage-component.spec.ts
@@ -138,6 +138,11 @@ describe('storage mock', () => {
     await expect(storage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
   })
 
+  it(`When a range with start past end of content is requested, then it throws a RangeError`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await expect(storage.retrieve(id, { start: 10, end: 20 })).rejects.toThrow(RangeError)
+  })
+
   async function retrieveAndExpectStoredContentToBe(idToRetrieve: string, expectedContent: Buffer) {
     const retrievedContent = await storage.retrieve(idToRetrieve)
     expect(await streamToBuffer(await retrievedContent!.asStream())).toEqual(expectedContent)

--- a/test/in-memory-storage-component.spec.ts
+++ b/test/in-memory-storage-component.spec.ts
@@ -86,6 +86,21 @@ describe('storage mock', () => {
     expect(retrievedContent?.encoding).toBeUndefined()
   })
 
+  it(`When a range is requested on a non-existent key, then it returns undefined`, async () => {
+    const item = await storage.retrieve('non-existent', { start: 0, end: 4 })
+    expect(item).toBeUndefined()
+  })
+
+  it(`When a single-byte range is requested, then it returns that byte`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 4, end: 4 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(1)
+    expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('o'))
+  })
+
   it(`When content is stored, then a range can be retrieved`, async () => {
     const data = Buffer.from('Hello, World!')
     await storage.storeStream(id, bufferToStream(data))

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -169,6 +169,11 @@ describe('S3 Storage', () => {
     await expect(storage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
   })
 
+  it(`When a range with start past end of file is requested, then it throws a RangeError`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await expect(storage.retrieve(id, { start: 10, end: 20 })).rejects.toThrow(RangeError)
+  })
+
   async function retrieveAndExpectStoredContentToBe(idToRetrieve: string, expectedContent: Buffer) {
     const retrievedContent = await storage.retrieve(idToRetrieve)
     expect(await streamToBuffer(await retrievedContent!.asStream())).toEqual(expectedContent)

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -115,6 +115,46 @@ describe('S3 Storage', () => {
     expect(retrievedContent?.encoding).toBeUndefined()
   })
 
+  // Note: mock-aws-s3 does not support the Range parameter, so stream content
+  // assertions are skipped. These tests verify our size calculation and validation logic.
+
+  it(`When content is stored, then a range retrieve returns correct size`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 0, end: 4 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(5)
+  })
+
+  it(`When content is stored, then a range in the middle returns correct size`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 7, end: 11 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(5)
+  })
+
+  it(`When a range with end beyond file size is requested, then it clamps to file size`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 7, end: 999 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(6)
+  })
+
+  it(`When a range with start > end is requested, then it throws a RangeError`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await expect(storage.retrieve(id, { start: 5, end: 2 })).rejects.toThrow(RangeError)
+  })
+
+  it(`When a range with negative start is requested, then it throws a RangeError`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await expect(storage.retrieve(id, { start: -1, end: 2 })).rejects.toThrow(RangeError)
+  })
+
   async function retrieveAndExpectStoredContentToBe(idToRetrieve: string, expectedContent: Buffer) {
     const retrievedContent = await storage.retrieve(idToRetrieve)
     expect(await streamToBuffer(await retrievedContent!.asStream())).toEqual(expectedContent)

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -209,4 +209,49 @@ describe('S3 Storage', () => {
 
     expect(await storage.fileInfo('non-existent-id')).toBeUndefined()
   })
+
+  it(`When multiple files exist, then fileInfoMultiple returns correct results for existing and non-existing keys`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+    await storage.storeStream(id2, bufferToStream(content2))
+
+    const result = await storage.fileInfoMultiple([id, id2, 'non-existent'])
+    expect(result.get(id)).toEqual({ encoding: null, size: 3 })
+    expect(result.get(id2)).toEqual({ encoding: null, size: 3 })
+    expect(result.get('non-existent')).toBeUndefined()
+  })
+})
+
+describe('S3 Storage edge cases', () => {
+  it(`When a file has ContentLength 0, then fileInfo returns size 0 instead of null`, async () => {
+    const headObjectResponse = { ETag: '"abc"', ContentLength: 0, ContentEncoding: undefined }
+    const mockS3 = {
+      headObject: jest.fn().mockReturnValue({ promise: () => Promise.resolve(headObjectResponse) }),
+      upload: jest.fn().mockReturnValue({ promise: () => Promise.resolve() }),
+      getObject: jest.fn().mockReturnValue({ createReadStream: () => bufferToStream(Buffer.alloc(0)) }),
+      deleteObjects: jest.fn().mockReturnValue({ promise: () => Promise.resolve() }),
+      listObjectsV2: jest.fn().mockReturnValue({ promise: () => Promise.resolve({ Contents: [], IsTruncated: false }) })
+    }
+    const logs = await createLogComponent({})
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, mockS3 as any, { Bucket: 'test' })
+
+    const info = await storage.fileInfo('empty-file')
+    expect(info).toEqual({ encoding: null, size: 0 })
+  })
+
+  it(`When headObject returns no ContentLength, then a range retrieve returns null size`, async () => {
+    const headObjectResponse = { ETag: '"abc"', ContentEncoding: undefined }
+    const mockS3 = {
+      headObject: jest.fn().mockReturnValue({ promise: () => Promise.resolve(headObjectResponse) }),
+      upload: jest.fn().mockReturnValue({ promise: () => Promise.resolve() }),
+      getObject: jest.fn().mockReturnValue({ createReadStream: () => bufferToStream(Buffer.from('Hello')) }),
+      deleteObjects: jest.fn().mockReturnValue({ promise: () => Promise.resolve() }),
+      listObjectsV2: jest.fn().mockReturnValue({ promise: () => Promise.resolve({ Contents: [], IsTruncated: false }) })
+    }
+    const logs = await createLogComponent({})
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, mockS3 as any, { Bucket: 'test' })
+
+    const item = await storage.retrieve('some-file', { start: 0, end: 4 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBeNull()
+  })
 })

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -118,6 +118,20 @@ describe('S3 Storage', () => {
   // Note: mock-aws-s3 does not support the Range parameter, so stream content
   // assertions are skipped. These tests verify our size calculation and validation logic.
 
+  it(`When a range is requested on a non-existent key, then it returns undefined`, async () => {
+    const item = await storage.retrieve('non-existent', { start: 0, end: 4 })
+    expect(item).toBeUndefined()
+  })
+
+  it(`When a single-byte range is requested, then it returns correct size`, async () => {
+    const data = Buffer.from('Hello, World!')
+    await storage.storeStream(id, bufferToStream(data))
+
+    const item = await storage.retrieve(id, { start: 4, end: 4 })
+    expect(item).toBeDefined()
+    expect(item!.size).toBe(1)
+  })
+
   it(`When content is stored, then a range retrieve returns correct size`, async () => {
     const data = Buffer.from('Hello, World!')
     await storage.storeStream(id, bufferToStream(data))


### PR DESCRIPTION
The way [unity-explorer](https://github.com/decentraland/unity-explorer) implements video textures depends on quirks of QuickTime when on macOS. In particular, the server must send the correct Content-Type and must support range requests.

One concrete case this fixes is the game arena. Currently, on macOS, all its animated banners are black.

Also see
- https://github.com/decentraland/js-sdk-toolchain/pull/1363