### PR TITLE
feat: add contentSize to FileInfo for range requests

### DIFF
--- a/src/content-item.ts
+++ b/src/content-item.ts
@@ -9,11 +9,12 @@ export class SimpleContentItem implements ContentItem {
   constructor(
     private streamCreator: () => Promise<Readable>,
     public size: number | null,
-    public encoding: string | null
+    public encoding: string | null,
+    public contentSize: number | null = size
   ) {}
 
   static fromBuffer(buffer: Uint8Array): SimpleContentItem {
-    return new SimpleContentItem(async () => bufferToStream(buffer), buffer.length, null)
+    return new SimpleContentItem(async () => bufferToStream(buffer), buffer.length, null, buffer.length)
   }
 
   /**

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -10,7 +10,7 @@ const pipe = promisify(pipeline)
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000
-const ONE_GB_IN_BYTES = 1024 * 1024 * 1024
+const FIVE_GB_IN_BYTES = 5 * 1024 * 1024 * 1024
 
 /** @public */
 export type FolderStorageOptions = {
@@ -18,7 +18,7 @@ export type FolderStorageOptions = {
   disablePrefixHash: boolean
   /** TTL in milliseconds for cached decompressed files. Default: 1 hour. */
   decompressCacheTTL?: number
-  /** Max total size in bytes for cached decompressed files. Default: 1GB. */
+  /** Max total size in bytes for cached decompressed files. Default: 5GB. */
   decompressCacheMaxSize?: number
   /** How often to run the eviction check in milliseconds. Default: 5 minutes. */
   decompressCacheEvictionInterval?: number
@@ -43,7 +43,7 @@ export async function createFolderBasedFileSystemContentStorage(
 
   const USE_HASH_PREFIX = !(options?.disablePrefixHash ?? false)
   const CACHE_TTL = options?.decompressCacheTTL ?? ONE_HOUR_IN_MS
-  const CACHE_MAX_SIZE = options?.decompressCacheMaxSize ?? ONE_GB_IN_BYTES
+  const CACHE_MAX_SIZE = options?.decompressCacheMaxSize ?? FIVE_GB_IN_BYTES
   const CACHE_EVICTION_INTERVAL = options?.decompressCacheEvictionInterval ?? FIVE_MINUTES_IN_MS
 
   // LRU cache tracker for decompressed gzip files written to disk

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { pipeline, Readable } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
-import { SimpleContentItem } from './content-item'
+import { SimpleContentItem, streamToBuffer } from './content-item'
 import { compressContentFile } from './extras/compression'
 
 const pipe = promisify(pipeline)
@@ -257,6 +257,23 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
+  async function readGzipOriginalSize(filePath: string, gzipSize: number): Promise<number | null> {
+    // The gzip format (RFC 1952) stores the original uncompressed size in its
+    // trailer — the last 4 bytes (ISIZE field, uint32 little-endian).
+    // This works for files < 4GB (ISIZE is mod 2^32).
+    if (gzipSize < 8) return null // Too small to be a valid gzip file
+    try {
+      const stream = components.fs.createReadStream(filePath, {
+        start: gzipSize - 4,
+        end: gzipSize - 1
+      })
+      const buffer = await streamToBuffer(stream)
+      return buffer.readUInt32LE(0)
+    } catch {
+      return null
+    }
+  }
+
   async function fileInfo(id: string): Promise<FileInfo | undefined> {
     const possibleEncondings = ['gzip', null]
     const baseFilePath = await getFilePath(id)
@@ -266,9 +283,18 @@ export async function createFolderBasedFileSystemContentStorage(
       const filePath = baseFilePath + extension
       if (await components.fs.existPath(filePath)) {
         const stat = await components.fs.stat(filePath)
+        if (encoding === 'gzip') {
+          const contentSize = await readGzipOriginalSize(filePath, stat.size)
+          return {
+            size: stat.size,
+            encoding,
+            contentSize
+          }
+        }
         return {
           size: stat.size,
-          encoding
+          encoding,
+          contentSize: stat.size
         }
       }
     }

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -10,7 +10,7 @@ export function createInMemoryStorage(): IContentStorageComponent {
 
   async function fileInfo(id: string): Promise<FileInfo | undefined> {
     const buffer = storage.get(id)
-    return buffer ? { encoding: null, size: buffer!.length } : undefined
+    return buffer ? { encoding: null, size: buffer!.length, contentSize: buffer!.length } : undefined
   }
 
   return {

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -178,9 +178,11 @@ export async function createS3BasedFileSystemContentStorage(
   async function fileInfo(id: string): Promise<FileInfo | undefined> {
     try {
       const obj = await s3.headObject({ Bucket, Key: getKey(id) }).promise()
+      const size = obj.ContentLength ?? null
       return {
         encoding: obj.ContentEncoding || null,
-        size: obj.ContentLength ?? null
+        size,
+        contentSize: obj.ContentEncoding ? null : size
       }
     } catch {
       return undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export type IContentStorageComponent = IBaseComponent & {
 export type FileInfo = {
   encoding: string | null
   size: number | null
+  /** Logical content size (uncompressed). Same as size when encoding is null. Null if unknown. */
+  contentSize: number | null
 }
 
 /**

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -495,6 +495,25 @@ describe('fileSystemContentStorage', () => {
     expect(info!.size).toBeLessThan(100)
   })
 
+  it(`When content is stored compressed (gzip only), then fileInfo returns the correct contentSize from the gzip trailer`, async () => {
+    const data = Buffer.from(new Uint8Array(100).fill(0))
+    await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))
+
+    const info = await fileSystemContentStorage.fileInfo(id)
+    expect(info).toBeDefined()
+    expect(info!.encoding).toBe('gzip')
+    expect(info!.contentSize).toBe(100)
+  })
+
+  it(`When content is stored uncompressed, then fileInfo returns contentSize equal to size`, async () => {
+    await fileSystemContentStorage.storeStream(id, bufferToStream(content))
+
+    const info = await fileSystemContentStorage.fileInfo(id)
+    expect(info).toBeDefined()
+    expect(info!.contentSize).toBe(info!.size)
+    expect(info!.contentSize).toBe(3)
+  })
+
   it(`When a cached file is accessed via range, then its lastAccess is updated and it survives LRU eviction`, async () => {
     jest.useFakeTimers()
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-touch-'))
@@ -561,10 +580,10 @@ describe('fileSystemContentStorage', () => {
 
     const exists = await fileSystemContentStorage.fileInfoMultiple([id, id2])
 
-    expect(exists.get(id)).toEqual({ encoding: null, size: 3 })
-    expect(exists.get(id2)).toEqual({ encoding: null, size: 3 })
-    expect(await fileSystemContentStorage.fileInfo(id)).toEqual({ encoding: null, size: 3 })
-    expect(await fileSystemContentStorage.fileInfo(id2)).toEqual({ encoding: null, size: 3 })
+    expect(exists.get(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(exists.get(id2)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(await fileSystemContentStorage.fileInfo(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(await fileSystemContentStorage.fileInfo(id2)).toEqual({ encoding: null, size: 3, contentSize: 3 })
     expect(await fileSystemContentStorage.fileInfo('non-existent-id')).toBeUndefined()
   })
 })

--- a/test/in-memory-storage-component.spec.ts
+++ b/test/in-memory-storage-component.spec.ts
@@ -173,8 +173,8 @@ describe('storage mock', () => {
 
     const exists = await storage.fileInfoMultiple([id])
 
-    expect(exists.get(id)).toEqual({ encoding: null, size: 3 })
-    expect(await storage.fileInfo(id)).toEqual({ encoding: null, size: 3 })
+    expect(exists.get(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(await storage.fileInfo(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
   })
 
   it(`When multiple files exist, then fileInfoMultiple returns correct results for existing and non-existing keys`, async () => {
@@ -182,8 +182,17 @@ describe('storage mock', () => {
     await storage.storeStream(id2, bufferToStream(content2))
 
     const result = await storage.fileInfoMultiple([id, id2, 'non-existent'])
-    expect(result.get(id)).toEqual({ encoding: null, size: 3 })
-    expect(result.get(id2)).toEqual({ encoding: null, size: 3 })
+    expect(result.get(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(result.get(id2)).toEqual({ encoding: null, size: 3, contentSize: 3 })
     expect(result.get('non-existent')).toBeUndefined()
+  })
+
+  it(`When content is stored, then fileInfo returns contentSize equal to size`, async () => {
+    await storage.storeStream(id, bufferToStream(content))
+
+    const info = await storage.fileInfo(id)
+    expect(info).toBeDefined()
+    expect(info!.contentSize).toBe(info!.size)
+    expect(info!.contentSize).toBe(3)
   })
 })

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -204,8 +204,8 @@ describe('S3 Storage', () => {
 
     const exists = await storage.fileInfoMultiple([id])
 
-    expect(exists.get(id)).toEqual({ encoding: null, size: 3 })
-    expect(await storage.fileInfo(id)).toEqual({ encoding: null, size: 3 })
+    expect(exists.get(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(await storage.fileInfo(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
 
     expect(await storage.fileInfo('non-existent-id')).toBeUndefined()
   })
@@ -215,8 +215,8 @@ describe('S3 Storage', () => {
     await storage.storeStream(id2, bufferToStream(content2))
 
     const result = await storage.fileInfoMultiple([id, id2, 'non-existent'])
-    expect(result.get(id)).toEqual({ encoding: null, size: 3 })
-    expect(result.get(id2)).toEqual({ encoding: null, size: 3 })
+    expect(result.get(id)).toEqual({ encoding: null, size: 3, contentSize: 3 })
+    expect(result.get(id2)).toEqual({ encoding: null, size: 3, contentSize: 3 })
     expect(result.get('non-existent')).toBeUndefined()
   })
 })
@@ -235,7 +235,7 @@ describe('S3 Storage edge cases', () => {
     const storage = await createS3BasedFileSystemContentStorage({ logs }, mockS3 as any, { Bucket: 'test' })
 
     const info = await storage.fileInfo('empty-file')
-    expect(info).toEqual({ encoding: null, size: 0 })
+    expect(info).toEqual({ encoding: null, size: 0, contentSize: 0 })
   })
 
   it(`When headObject returns no ContentLength, then a range retrieve returns null size`, async () => {


### PR DESCRIPTION
## Why

When files are stored as gzip, `fileInfo().size` returns the compressed size on disk. However, `retrieve(hash, range)` serves byte ranges from the **uncompressed** content — it skips gzip for range requests, decompresses to a disk cache, and slices from the uncompressed file.

This mismatch means HTTP consumers using `fileInfo().size` as the total for `Content-Range` headers get the wrong value. For example, a 1000-byte file compressed to 500 bytes would report `Content-Range: bytes 0-99/500`, causing clients to think the file is 500 bytes. Download resumption stops at byte 499, silently truncating the file. Range requests for bytes 500–999 are rejected as unsatisfiable even though the content exists.

## What changed

**`contentSize` field on `FileInfo`** — a new required field representing the logical (uncompressed) content size. `size` retains its existing meaning (on-disk/stored size) for backward compatibility.

**Gzip trailer reading** — For gzip files, `contentSize` is read from the ISIZE field in the gzip trailer (last 4 bytes of the file, per RFC 1952). This is the standard way gzip stores the original uncompressed size. It requires no sidecar metadata files, no changes to the compression code, and works retroactively on all existing `.gzip` files already on disk. The only limitation is that ISIZE is stored mod 2^32, so it wraps for files ≥ 4GB — not a practical concern for Decentraland content.

**Per-backend behavior:**
- **Folder-based storage:** reads gzip trailer for compressed files, `contentSize === size` for uncompressed
- **In-memory storage:** `contentSize === size` (no compression)
- **S3 storage:** `contentSize` is `null` when `ContentEncoding` is present (can't determine uncompressed size without downloading the object tail), otherwise `contentSize === size`

**Cache default increase** — bumped the decompression cache max size from 1GB to 5GB to reduce re-decompressions under range request load.