### PR TITLE
feat: stream S3 uploads instead of buffering the whole file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build:watch": "tsc -p tsconfig.json --watch",
     "lint:check": "eslint '**/*.{js,ts}'",
     "lint:fix": "eslint '**/*.{js,ts}' --fix",
-    "test": "jest --forceExit --detectOpenHandles --verbose",
-    "test:coverage": "jest --forceExit --detectOpenHandles --coverage --verbose"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --forceExit --detectOpenHandles --verbose",
+    "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --forceExit --detectOpenHandles --coverage --verbose"
   },
   "repository": {
     "type": "git",
@@ -39,6 +39,7 @@
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/logger": "^3.1.2",
     "@well-known-components/test-helpers": "^1.5.2",
+    "cross-env": "^10.1.0",
     "mock-aws-s3": "^4.0.2",
     "typescript": "^4.9.5"
   },

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -7,27 +7,47 @@ import { ListObjectsV2Output } from 'aws-sdk/clients/s3'
 // This indirection preserves the native import() needed for ESM-only packages.
 const _importDynamic = Function('modulePath', 'return import(modulePath)') as (modulePath: string) => Promise<any>
 
-/**
- * Helper function to convert a buffer to a readable stream.
- */
-function bufferToStream(buffer: Buffer): Readable {
-  const stream = new Readable()
-  stream.push(buffer)
-  stream.push(null) // End of stream
-  return stream
-}
+const MIME_DETECTION_BYTES = 4100
 
 /**
- * Helper function to buffer a stream for MIME type detection and further usage.
+ * Reads the first `byteCount` bytes from the stream for inspection, then returns those bytes
+ * together with a Readable that re-emits them followed by the remainder of the original stream.
+ * This lets us detect the MIME type from the head while streaming the body straight to S3, so
+ * large files are never buffered in memory in full.
  */
-async function streamToBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = []
-  for await (const chunk of stream) {
-    // Ensure chunk is converted to Buffer (handles Uint8Array, Buffer, etc.)
-    const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-    chunks.push(bufferChunk)
+async function peekHead(stream: Readable, byteCount: number): Promise<{ head: Buffer; body: Readable }> {
+  const iterator = stream[Symbol.asyncIterator]()
+  const headChunks: Buffer[] = []
+  let headLength = 0
+  let finished = false
+
+  while (headLength < byteCount) {
+    const next = await iterator.next()
+    if (next.done) {
+      finished = true
+      break
+    }
+    const chunk = Buffer.isBuffer(next.value) ? next.value : Buffer.from(next.value)
+    headChunks.push(chunk)
+    headLength += chunk.length
   }
-  return Buffer.concat(chunks)
+
+  const head = Buffer.concat(headChunks)
+
+  const body = Readable.from(
+    (async function* () {
+      yield head
+      if (!finished) {
+        let next = await iterator.next()
+        while (!next.done) {
+          yield Buffer.isBuffer(next.value) ? next.value : Buffer.from(next.value)
+          next = await iterator.next()
+        }
+      }
+    })()
+  )
+
+  return { head, body }
 }
 
 /**
@@ -89,18 +109,17 @@ export async function createS3BasedFileSystemContentStorage(
   }
 
   async function storeStream(id: string, stream: Readable): Promise<void> {
-    // Buffer the entire stream to detect MIME type and upload
-    const fullBuffer = await streamToBuffer(stream)
+    // Inspect only the head for MIME detection, then stream the body straight to S3 so large
+    // files are never buffered in memory. The AWS SDK's managed upload performs a multipart
+    // upload, buffering only part-sized chunks rather than the whole file.
+    const { head, body } = await peekHead(stream, MIME_DETECTION_BYTES)
+    const mimeType = await detectMimeTypeFromBuffer(head)
 
-    // Detect MIME type from the buffer
-    const mimeType = await detectMimeTypeFromBuffer(fullBuffer)
-
-    // Upload to S3 using the buffered data
     await s3
       .upload({
         Bucket,
         Key: getKey(id),
-        Body: bufferToStream(fullBuffer),
+        Body: body,
         ContentType: mimeType
       })
       .promise()

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -10,10 +10,11 @@ const _importDynamic = Function('modulePath', 'return import(modulePath)') as (m
 const MIME_DETECTION_BYTES = 4100
 
 /**
- * Reads the first `byteCount` bytes from the stream for inspection, then returns those bytes
- * together with a Readable that re-emits them followed by the remainder of the original stream.
- * This lets us detect the MIME type from the head while streaming the body straight to S3, so
- * large files are never buffered in memory in full.
+ * Reads at least the first `byteCount` bytes from the stream for inspection (chunk-granular, so it
+ * may read a bit more — up to a whole chunk past the target), then returns those bytes together
+ * with a Readable that re-emits them followed by the remainder of the original stream. This lets us
+ * detect the MIME type from the head while streaming the body straight to S3, so large files are
+ * never buffered in memory in full.
  */
 async function peekHead(stream: Readable, byteCount: number): Promise<{ head: Buffer; body: Readable }> {
   const iterator = stream[Symbol.asyncIterator]()
@@ -36,13 +37,20 @@ async function peekHead(stream: Readable, byteCount: number): Promise<{ head: Bu
 
   const body = Readable.from(
     (async function* () {
-      yield head
-      if (!finished) {
-        let next = await iterator.next()
-        while (!next.done) {
-          yield Buffer.isBuffer(next.value) ? next.value : Buffer.from(next.value)
-          next = await iterator.next()
+      try {
+        yield head
+        if (!finished) {
+          let next = await iterator.next()
+          while (!next.done) {
+            yield Buffer.isBuffer(next.value) ? next.value : Buffer.from(next.value)
+            next = await iterator.next()
+          }
         }
+      } finally {
+        // Release the source stream whenever consumption stops — normal end, or early
+        // termination such as the body being destroyed after a failed upload — so its
+        // underlying resources (e.g. file descriptors) are not leaked.
+        await iterator.return?.()
       }
     })()
   )
@@ -115,14 +123,23 @@ export async function createS3BasedFileSystemContentStorage(
     const { head, body } = await peekHead(stream, MIME_DETECTION_BYTES)
     const mimeType = await detectMimeTypeFromBuffer(head)
 
-    await s3
-      .upload({
-        Bucket,
-        Key: getKey(id),
-        Body: body,
-        ContentType: mimeType
-      })
-      .promise()
+    try {
+      await s3
+        .upload({
+          Bucket,
+          Key: getKey(id),
+          Body: body,
+          ContentType: mimeType
+        })
+        .promise()
+    } catch (error) {
+      // Release the source stream if the upload stopped consuming the body (e.g. it failed before
+      // reading anything, so peekHead's generator never started and can't self-clean). Destroying
+      // the source releases its underlying resources (e.g. file descriptors). No-op if already
+      // ended/destroyed.
+      stream.destroy()
+      throw error
+    }
   }
 
   async function retrieve(id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -8,6 +8,7 @@ import { bufferToStream, streamToBuffer } from '../src'
 import { FileSystemUtils as fsu } from './file-system-utils'
 import AWSMock from 'mock-aws-s3'
 import { Readable } from 'stream'
+import { once } from 'events'
 import { createLogComponent } from '@well-known-components/logger'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 
@@ -319,5 +320,26 @@ describe('S3 Storage edge cases', () => {
     const item = await storage.retrieve('some-file', { start: 0, end: 4 })
     expect(item).toBeDefined()
     expect(item!.size).toBeNull()
+  })
+
+  it(`When the upload fails, then the source stream is released`, async () => {
+    const mockS3 = {
+      headObject: jest.fn().mockReturnValue({ promise: () => Promise.resolve({}) }),
+      upload: jest.fn().mockReturnValue({ promise: () => Promise.reject(new Error('upload failed')) }),
+      getObject: jest.fn(),
+      deleteObjects: jest.fn().mockReturnValue({ promise: () => Promise.resolve() }),
+      listObjectsV2: jest.fn().mockReturnValue({ promise: () => Promise.resolve({ Contents: [], IsTruncated: false }) })
+    }
+    const logs = await createLogComponent({})
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, mockS3 as any, { Bucket: 'test' })
+
+    // Two chunks so the body still has unread data after the head is peeked.
+    const source = Readable.from([Buffer.alloc(5000, 1), Buffer.alloc(5000, 1)])
+    const closed = once(source, 'close')
+
+    await expect(storage.storeStream('fail-id', source)).rejects.toThrow('upload failed')
+    await closed
+
+    expect(source.destroyed).toBe(true)
   })
 })

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -236,6 +236,57 @@ describe('S3 Storage', () => {
   })
 })
 
+describe('S3 Storage MIME type detection', () => {
+  let storage: IContentStorageComponent
+  let uploadSpy: jest.SpyInstance
+
+  // Each payload is padded well beyond the detection window so the test proves the type is
+  // detected from the head alone, without buffering the whole file.
+  const padding = Buffer.alloc(8192, 0)
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52]),
+    padding
+  ])
+  const jpeg = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0x10, 0x4a, 0x46, 0x49, 0x46, 0]), padding])
+  const glb = Buffer.concat([Buffer.from('glTF'), Buffer.from([2, 0, 0, 0, 0x10, 0, 0, 0]), padding])
+  const gltfJson = Buffer.from(JSON.stringify({ asset: { version: '2.0' } }))
+
+  beforeEach(async () => {
+    const root = fsu.createTempDirectory()
+    AWSMock.config.basePath = path.join(root, 'buckets')
+    const s3 = new AWSMock.S3({ params: { Bucket: 'example' } })
+    uploadSpy = jest.spyOn(s3, 'upload')
+    const logs = await createLogComponent({})
+    storage = await createS3BasedFileSystemContentStorage({ logs }, s3, { Bucket: 'example' })
+  })
+
+  const uploadedContentType = (): string => uploadSpy.mock.calls[0][0].ContentType
+
+  it(`When a PNG larger than the detection window is stored, then it is uploaded as image/png`, async () => {
+    await storage.storeStream('png-id', bufferToStream(png))
+
+    expect(uploadedContentType()).toBe('image/png')
+  })
+
+  it(`When a JPEG larger than the detection window is stored, then it is uploaded as image/jpeg`, async () => {
+    await storage.storeStream('jpeg-id', bufferToStream(jpeg))
+
+    expect(uploadedContentType()).toBe('image/jpeg')
+  })
+
+  it(`When a binary glTF (GLB) larger than the detection window is stored, then it is uploaded as model/gltf-binary`, async () => {
+    await storage.storeStream('glb-id', bufferToStream(glb))
+
+    expect(uploadedContentType()).toBe('model/gltf-binary')
+  })
+
+  it(`When a text-based glTF (JSON) is stored, then it falls back to application/octet-stream`, async () => {
+    await storage.storeStream('gltf-id', bufferToStream(gltfJson))
+
+    expect(uploadedContentType()).toBe('application/octet-stream')
+  })
+})
+
 describe('S3 Storage edge cases', () => {
   it(`When a file has ContentLength 0, then fileInfo returns size 0 instead of null`, async () => {
     const headObjectResponse = { ETag: '"abc"', ContentLength: 0, ContentEncoding: undefined }

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -7,6 +7,7 @@ import {
 import { bufferToStream, streamToBuffer } from '../src'
 import { FileSystemUtils as fsu } from './file-system-utils'
 import AWSMock from 'mock-aws-s3'
+import { Readable } from 'stream'
 import { createLogComponent } from '@well-known-components/logger'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 
@@ -50,6 +51,20 @@ describe('S3 Storage', () => {
     await storage.storeStream(id, bufferToStream(content))
 
     await retrieveAndExpectStoredContentToBe(id, content)
+  })
+
+  it(`When a large multi-chunk stream is stored, then the full content is preserved across the MIME-detection boundary`, async () => {
+    // Larger than the 4100-byte MIME-detection head, delivered in 1KB chunks so the head spans
+    // several chunks. Exercises the peek-and-restream path that avoids buffering the whole file.
+    const largeContent = Buffer.alloc(10000, 7)
+    const chunks: Buffer[] = []
+    for (let offset = 0; offset < largeContent.length; offset += 1000) {
+      chunks.push(largeContent.subarray(offset, offset + 1000))
+    }
+
+    await storage.storeStream('large-id', Readable.from(chunks))
+
+    await retrieveAndExpectStoredContentToBe('large-id', largeContent)
   })
 
   it(`When content is stored, then we can check if it exists`, async function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,11 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.2.4"
 
+"@epic-web/invariant@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
+  integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"
@@ -1464,10 +1469,27 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cross-env@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-10.1.0.tgz#cfd2a6200df9ed75bfb9cb3d7ce609c13ea21783"
+  integrity sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==
+  dependencies:
+    "@epic-web/invariant" "^1.0.0"
+    cross-spawn "^7.0.6"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
## Problem

`storeStream` on the S3 storage component buffered the **entire** stream into memory (`streamToBuffer` → `Buffer.concat`) to detect the MIME type before uploading. A large content file was therefore held in RAM in full for the duration of its upload. For services that store user-uploaded content (e.g. worlds-content-server deployments), concurrent large uploads multiply this and can exhaust a small container's memory.

## Change

- **Stream instead of buffer:** peek only the head of the stream (MIME detection needs ~4100 bytes) via a new `peekHead` helper, then reconstruct the body stream (head + remainder) and hand it to the AWS SDK's managed `s3.upload`, which performs a **multipart upload** buffering only part-sized chunks, not the whole file. Peak memory per upload drops from the full file size to a few MB.
- Removed the now-unused private `streamToBuffer`/`bufferToStream` helpers in this file (the public ones in `content-item.ts` are untouched).

Folder-based storage already streams to disk (`pipe(stream, createWriteStream)`), so only the S3 path is changed.

## Tests

- Round-trip test storing a 10 KB stream delivered in 1 KB chunks (head spans multiple chunks, crosses the 4100-byte boundary) — asserts the content is preserved.
- **MIME-type detection integration tests** (new): assert that PNG / JPEG / binary-glTF (GLB) payloads **larger than the detection window** are uploaded with the correct `ContentType` (`image/png`, `image/jpeg`, `model/gltf-binary`), and that a text-based glTF (JSON) falls back to `application/octet-stream`. This proves the type is detected from the head alone, without buffering the whole file.

### Jest ESM hardening (required for the MIME tests)

`file-type` v21 is ESM-only and is loaded via a native dynamic `import()`. That works in production (real `node` imports the ESM fine) but **threw silently under jest** (`A dynamic import callback was invoked without --experimental-vm-modules`), so `detectMimeTypeFromBuffer` fell back to `application/octet-stream` and MIME detection was **never actually exercised** by the suite.

- Run jest with `NODE_OPTIONS=--experimental-vm-modules` (via a new `cross-env` devDependency) so the real detection runs in tests.
- The suite already runs in-band (`--detectOpenHandles`), so the flag applies deterministically in the main process — verified green across repeated `yarn test` / `yarn test:coverage` runs.