### PR TITLE
fix: cap gzip decompression size to prevent a decompression bomb

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto'
 import path from 'path'
-import { pipeline, Readable } from 'stream'
+import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
@@ -22,6 +22,32 @@ export type FolderStorageOptions = {
   decompressCacheMaxSize?: number
   /** How often to run the eviction check in milliseconds. Default: 5 minutes. */
   decompressCacheEvictionInterval?: number
+  /**
+   * Max size in bytes a single gzip item may inflate to when serving a range request. Inflation is
+   * aborted past this limit, preventing a decompression bomb from writing an unbounded amount to
+   * disk. Defaults to `decompressCacheMaxSize` (a file larger than the whole cache could never be
+   * cached anyway).
+   */
+  decompressMaxFileSize?: number
+}
+
+/**
+ * A Transform that passes bytes through unchanged but errors once more than `maxBytes` have flowed
+ * through it. Used to cap how much a gzip item may inflate to, so a decompression bomb cannot write
+ * an unbounded amount of data to disk.
+ */
+function createSizeLimitTransform(maxBytes: number): Transform {
+  let total = 0
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      total += chunk.length
+      if (total > maxBytes) {
+        callback(new Error(`Decompressed size exceeds the maximum allowed of ${maxBytes} bytes`))
+        return
+      }
+      callback(null, chunk)
+    }
+  })
 }
 
 /**
@@ -45,6 +71,7 @@ export async function createFolderBasedFileSystemContentStorage(
   const CACHE_TTL = options?.decompressCacheTTL ?? ONE_HOUR_IN_MS
   const CACHE_MAX_SIZE = options?.decompressCacheMaxSize ?? FIVE_GB_IN_BYTES
   const CACHE_EVICTION_INTERVAL = options?.decompressCacheEvictionInterval ?? FIVE_MINUTES_IN_MS
+  const MAX_DECOMPRESSED_SIZE = options?.decompressMaxFileSize ?? CACHE_MAX_SIZE
 
   // LRU cache tracker for decompressed gzip files written to disk
   const decompressCache = new Map<string, { size: number; lastAccess: number }>()
@@ -203,9 +230,16 @@ export async function createFolderBasedFileSystemContentStorage(
           if (gzipItem) {
             decompressPromise = (async () => {
               try {
-                await pipe(await gzipItem.asStream(), components.fs.createWriteStream(uncompressedPath))
+                // Cap how much the gzip may inflate to so a decompression bomb cannot write an
+                // unbounded file to disk. The gzip trailer's declared size is attacker-controllable,
+                // so the limit is enforced on the actual inflated bytes, not a declared value.
+                await pipe(
+                  await gzipItem.asStream(),
+                  createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
+                  components.fs.createWriteStream(uncompressedPath)
+                )
               } catch (err) {
-                // Remove partial file to prevent serving corrupt data
+                // Remove partial file to prevent serving corrupt data (or a partially-written bomb)
                 await noFailUnlink(uncompressedPath)
                 throw err
               }

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -487,6 +487,109 @@ describe('fileSystemContentStorage', () => {
     }
   })
 
+  it(`When a gzip inflates to exactly the max decompressed size, then the range request succeeds`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-boundary-'))
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs, logs: await createLogComponent({}) },
+      tmpDir,
+      { decompressMaxFileSize: 1000 }
+    )
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    try {
+      // Inflates to exactly 1000 bytes — at (not over) the cap, so it must be allowed.
+      const data = Buffer.from(new Uint8Array(1000).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+
+      const item = await storage.retrieve(id, { start: 0, end: 9 })
+      expect(item).toBeDefined()
+      expect(item!.size).toBe(10)
+      expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.alloc(10, 0))
+      // Decompression succeeded and was cached.
+      expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it(`When two range requests race for a gzip that exceeds the cap, then both are refused and nothing is left behind`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-bomb-race-'))
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs, logs: await createLogComponent({}) },
+      tmpDir,
+      { decompressMaxFileSize: 50 }
+    )
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    try {
+      const data = Buffer.from(new Uint8Array(1000).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+
+      // Two simultaneous range requests exercise the inflight-decompression guard on the error path.
+      const [a, b] = await Promise.all([
+        storage.retrieve(id, { start: 0, end: 9 }),
+        storage.retrieve(id, { start: 0, end: 9 })
+      ])
+      expect(a).toBeUndefined()
+      expect(b).toBeUndefined()
+      expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+
+      // The guard is not left stuck: a subsequent request is still cleanly refused.
+      expect(await storage.retrieve(id, { start: 0, end: 9 })).toBeUndefined()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it(`When decompressMaxFileSize is unset, then it inherits decompressCacheMaxSize and allows files within it`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-default-ok-'))
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs, logs: await createLogComponent({}) },
+      tmpDir,
+      { decompressCacheMaxSize: 2000 }
+    )
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    try {
+      // 1000 bytes is within the inherited 2000-byte limit, so it decompresses normally.
+      const data = Buffer.from(new Uint8Array(1000).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+
+      const item = await storage.retrieve(id, { start: 0, end: 9 })
+      expect(item).toBeDefined()
+      expect(item!.size).toBe(10)
+      expect(await fs.existPath(cachedFilePath)).toBeTruthy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it(`When decompressMaxFileSize is unset, then a file larger than decompressCacheMaxSize is refused`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-default-cap-'))
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs, logs: await createLogComponent({}) },
+      tmpDir,
+      { decompressCacheMaxSize: 500 }
+    )
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    try {
+      // 1000 bytes exceeds the inherited 500-byte limit (proving the cap came from
+      // decompressCacheMaxSize, not the multi-GB fallback), so it is refused.
+      const data = Buffer.from(new Uint8Array(1000).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+
+      expect(await storage.retrieve(id, { start: 0, end: 9 })).toBeUndefined()
+      expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   it(`When content is stored compressed (gzip only), then exist returns true`, async () => {
     const data = Buffer.from(new Uint8Array(100).fill(0))
     await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -458,6 +458,35 @@ describe('fileSystemContentStorage', () => {
     }
   })
 
+  it(`When a gzip item inflates beyond the max decompressed size, then the range request is refused and no oversized file is written`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-bomb-'))
+    // Cap decompression at 50 bytes; the payload below inflates to 1000.
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs, logs: await createLogComponent({}) },
+      tmpDir,
+      { decompressMaxFileSize: 50 }
+    )
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    try {
+      // 1000 zero bytes compress to a tiny gzip but inflate well past the 50-byte cap.
+      const data = Buffer.from(new Uint8Array(1000).fill(0))
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+      expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
+
+      // The range request triggers decompression, which is aborted at the cap.
+      const item = await storage.retrieve(id, { start: 0, end: 9 })
+      expect(item).toBeUndefined()
+
+      // No oversized uncompressed cache file is left behind; the gzip is untouched.
+      expect(await fs.existPath(cachedFilePath)).toBeFalsy()
+      expect(await fs.existPath(cachedFilePath + '.gzip')).toBeTruthy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   it(`When content is stored compressed (gzip only), then exist returns true`, async () => {
     const data = Buffer.from(new Uint8Array(100).fill(0))
     await fileSystemContentStorage.storeStreamAndCompress(id, bufferToStream(data))


### PR DESCRIPTION
Fixes #99.

## Problem

When serving a **range request** for a gzip-stored item, `retrieve` inflates the gzip into an uncompressed cache file on disk with **no size limit** (`folder-based-storage-component.ts`, the `pipe(gzipItem.asStream(), createWriteStream(...))` path). A small crafted gzip can expand to an arbitrarily large file → disk/CPU exhaustion (decompression bomb).

## Fix

Inflation now flows through a size-limiting `Transform` that aborts the pipe once the decompressed output exceeds a cap:

```ts
await pipe(
  await gzipItem.asStream(),
  createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
  components.fs.createWriteStream(uncompressedPath)
)
```

- The limit is enforced on the **actual inflated bytes**, not the gzip trailer's declared `ISIZE` — the trailer is part of the (possibly malicious) gzip file, so a declared-size pre-check alone is bypassable.
- On abort, the existing `catch` unlinks the partial file and `retrieve` returns `undefined` (refuses to serve the bomb).
- New option `decompressMaxFileSize` (bytes). **Default = `decompressCacheMaxSize`** (5 GB): a file larger than the whole cache could never be cached anyway, so this is non-breaking for legitimate content while bounding a bomb. Operators with smaller content can tune it down.

## Notes

- Only the folder-based S3-cache decompression path is affected; `asStream()` gunzips, so the transform counts decompressed bytes.
- The sibling `streamToBuffer`-without-cap in `s3-based-storage-component.ts` noted in the issue is gated upstream by the 350 MB multipart limit and is out of scope here.

## Tests

Added: a gzip that inflates past a configured 50-byte cap → the range request is refused (`undefined`), no oversized uncompressed file is written, and the `.gzip` is left untouched. Full suite green (`yarn test`): 7 suites, 114 passed.