### PR TITLE
fix: harden folder storage path containment against prefix confusion

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -130,7 +130,11 @@ export async function createFolderBasedFileSystemContentStorage(
     // recursively creates the directory structure if needed
     const dirname = path.dirname(finalPath)
 
-    if (!finalPath.startsWith(directoryPath)) {
+    // Containment check. We compare against `directoryPath + path.sep` (not a bare `startsWith`)
+    // so a sibling directory that merely shares the prefix — e.g. id "../<root>-evil/x" resolving
+    // to "<root>-evil" — cannot pass: "/data/contents-evil".startsWith("/data/contents") is true,
+    // but it is outside "/data/contents/".
+    if (finalPath !== directoryPath && !finalPath.startsWith(directoryPath + path.sep)) {
       throw new Error('Cannot manipulate files outside of the root storage folder')
     }
 
@@ -295,6 +299,9 @@ export async function createFolderBasedFileSystemContentStorage(
     // The gzip format (RFC 1952) stores the original uncompressed size in its
     // trailer — the last 4 bytes (ISIZE field, uint32 little-endian).
     // This works for files < 4GB (ISIZE is mod 2^32).
+    // SECURITY: the trailer is part of the stored (possibly attacker-controlled) file, so this is
+    // only a hint — it is never used to bound decompression (see createSizeLimitTransform) and
+    // callers must not trust it for allocation or limits.
     if (gzipSize < 8) return null // Too small to be a valid gzip file
     try {
       const stream = components.fs.createReadStream(filePath, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,13 @@ export type IContentStorageComponent = IBaseComponent & {
 export type FileInfo = {
   encoding: string | null
   size: number | null
-  /** Logical content size (uncompressed). Same as size when encoding is null. Null if unknown. */
+  /**
+   * Logical content size (uncompressed). Same as size when encoding is null. Null if unknown.
+   *
+   * SECURITY: for gzip-encoded content this is read from the gzip ISIZE trailer, which is part of
+   * the stored (potentially attacker-controlled) file and is only accurate mod 2^32. Treat it as a
+   * hint for display only — never rely on it for buffer allocation or size-limit enforcement.
+   */
   contentSize: number | null
 }
 

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -718,4 +718,70 @@ describe('fileSystemContentStorage', () => {
     expect(await fileSystemContentStorage.fileInfo(id2)).toEqual({ encoding: null, size: 3, contentSize: 3 })
     expect(await fileSystemContentStorage.fileInfo('non-existent-id')).toBeUndefined()
   })
+
+  describe('path containment', () => {
+    it(`When an id escapes the root via a sibling-prefix path, then it is rejected and nothing is written outside the root`, async () => {
+      // disablePrefixHash makes the root itself the containment dir, which is where the
+      // sibling-prefix bypass would escape (e.g. "/data/contents" vs "/data/contents-evil").
+      const root = mkdtempSync(path.join(os.tmpdir(), 'cs-traversal-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        root,
+        { disablePrefixHash: true }
+      )
+      // A sibling directory sharing the root's name prefix: ".../<rootBasename>X".
+      const siblingDir = path.join(path.dirname(root), path.basename(root) + 'X')
+      const escapingId = path.join('..', path.basename(root) + 'X', 'escaped')
+
+      try {
+        await expect(storage.storeStream(escapingId, bufferToStream(Buffer.from('x')))).rejects.toThrow(
+          /outside of the root/
+        )
+        await expect(storage.exist(escapingId)).rejects.toThrow(/outside of the root/)
+        expect(await fs.existPath(siblingDir)).toBeFalsy()
+      } finally {
+        await storage.stop?.()
+        rmSync(root, { recursive: true, force: true })
+        rmSync(siblingDir, { recursive: true, force: true })
+      }
+    })
+
+    it(`When an id traverses above the root, then it is rejected`, async () => {
+      const root = mkdtempSync(path.join(os.tmpdir(), 'cs-traversal-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        root,
+        { disablePrefixHash: true }
+      )
+
+      try {
+        await expect(storage.storeStream('../../../tmp/escaped', bufferToStream(Buffer.from('x')))).rejects.toThrow(
+          /outside of the root/
+        )
+      } finally {
+        await storage.stop?.()
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+
+    it(`When a normal id is used, then it is stored and retrieved within the root`, async () => {
+      const root = mkdtempSync(path.join(os.tmpdir(), 'cs-traversal-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        root,
+        { disablePrefixHash: true }
+      )
+
+      try {
+        await storage.storeStream('normal-id', bufferToStream(Buffer.from('hello')))
+        const item = await storage.retrieve('normal-id')
+        expect(item).toBeDefined()
+        expect(await streamToBuffer(await item!.asStream())).toEqual(Buffer.from('hello'))
+        expect(await fs.existPath(path.join(root, 'normal-id'))).toBeTruthy()
+      } finally {
+        await storage.stop?.()
+        rmSync(root, { recursive: true, force: true })
+      }
+    })
+  })
 })


### PR DESCRIPTION
Hardening found during a security re-review of `main`.

## Path containment (the fix)

`getFilePath` guarded against traversal with:

```ts
if (!finalPath.startsWith(directoryPath)) { throw ... }
```

`startsWith` without a trailing separator is prefix-confusable: a sibling directory that merely shares the prefix passes the check —
`"/data/contents-evil".startsWith("/data/contents")` is `true`. With `disablePrefixHash: true` (where the root itself is the containment dir), an `id` like `../<root-basename>-evil/x` resolves **outside** the storage root yet passes, allowing read/write/delete outside root. With the default hash-prefix it stays within root but can break shard containment.

Verified: `id = "../contents-evil/pwned"` with root `/data/contents` → `finalPath = /data/contents-evil/pwned`, old check returns `true`.

Fix — compare against `directoryPath + path.sep` (still allowing the directory itself):

```ts
if (finalPath !== directoryPath && !finalPath.startsWith(directoryPath + path.sep)) { throw ... }
```

**Exposure:** requires an `id` containing `../` and separators. Catalyst ids are normally validated content hashes (no slashes), so this is defense-in-depth rather than a known live exploit — but the check is *meant* to be the containment boundary and was subtly broken.

## Also: document untrusted `contentSize`

For gzip content, `FileInfo.contentSize` is read from the gzip ISIZE trailer, which is part of the (attacker-controllable) stored file and only accurate mod 2³². Added a SECURITY note on the `FileInfo` type and the helper that it's a display hint only — never use it for allocation or size-limit enforcement. (Decompression itself is already bounded by the actual inflated bytes, not this value — see #101.)

## Tests

Added a `path containment` suite: a sibling-prefix escape is rejected (and nothing is written outside root), an above-root traversal is rejected, and a normal id still stores/retrieves within root. Full suite green (`yarn test`): 7 suites, 127 passed.