### PR TITLE
fix: decouple decompression cap default from cache size (256MB)

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -11,6 +11,7 @@ const pipe = promisify(pipeline)
 const ONE_HOUR_IN_MS = 60 * 60 * 1000
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000
 const FIVE_GB_IN_BYTES = 5 * 1024 * 1024 * 1024
+const TWO_HUNDRED_FIFTY_SIX_MB_IN_BYTES = 256 * 1024 * 1024
 
 /** @public */
 export type FolderStorageOptions = {
@@ -25,8 +26,9 @@ export type FolderStorageOptions = {
   /**
    * Max size in bytes a single gzip item may inflate to when serving a range request. Inflation is
    * aborted past this limit, preventing a decompression bomb from writing an unbounded amount to
-   * disk. Defaults to `decompressCacheMaxSize` (a file larger than the whole cache could never be
-   * cached anyway).
+   * disk. Defaults to 256MB — comfortably above any realistic single compressible content file
+   * while keeping a malicious gzip's footprint small (and far below the whole-cache budget). Raise
+   * it only if legitimate gzipped content can be larger.
    */
   decompressMaxFileSize?: number
 }
@@ -71,7 +73,7 @@ export async function createFolderBasedFileSystemContentStorage(
   const CACHE_TTL = options?.decompressCacheTTL ?? ONE_HOUR_IN_MS
   const CACHE_MAX_SIZE = options?.decompressCacheMaxSize ?? FIVE_GB_IN_BYTES
   const CACHE_EVICTION_INTERVAL = options?.decompressCacheEvictionInterval ?? FIVE_MINUTES_IN_MS
-  const MAX_DECOMPRESSED_SIZE = options?.decompressMaxFileSize ?? CACHE_MAX_SIZE
+  const MAX_DECOMPRESSED_SIZE = options?.decompressMaxFileSize ?? TWO_HUNDRED_FIFTY_SIX_MB_IN_BYTES
 
   // LRU cache tracker for decompressed gzip files written to disk
   const decompressCache = new Map<string, { size: number; lastAccess: number }>()

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -543,17 +543,19 @@ describe('fileSystemContentStorage', () => {
     }
   })
 
-  it(`When decompressMaxFileSize is unset, then it inherits decompressCacheMaxSize and allows files within it`, async () => {
-    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-default-ok-'))
+  it(`When decompressMaxFileSize is unset, then the per-file cap is its own default, independent of decompressCacheMaxSize`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-default-cap-'))
+    // Cache budget far below the per-file default (256MB). A 1000-byte file is larger than the
+    // cache budget but well under the per-file cap, so it must still decompress — proving the
+    // per-file cap is no longer inherited from decompressCacheMaxSize.
     const storage = await createFolderBasedFileSystemContentStorage(
       { fs, logs: await createLogComponent({}) },
       tmpDir,
-      { decompressCacheMaxSize: 2000 }
+      { decompressCacheMaxSize: 500 }
     )
     const cachedFilePath = path.join(tmpDir, '9584', id)
 
     try {
-      // 1000 bytes is within the inherited 2000-byte limit, so it decompresses normally.
       const data = Buffer.from(new Uint8Array(1000).fill(0))
       await storage.storeStreamAndCompress(id, bufferToStream(data))
 
@@ -567,18 +569,18 @@ describe('fileSystemContentStorage', () => {
     }
   })
 
-  it(`When decompressMaxFileSize is unset, then a file larger than decompressCacheMaxSize is refused`, async () => {
-    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-default-cap-'))
+  it(`When decompressMaxFileSize is explicitly set, then it overrides the default and caps decompression`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-explicit-cap-'))
+    // A small explicit per-file cap (50 bytes) still applies even with a large cache budget,
+    // confirming the override path is unaffected by the new default.
     const storage = await createFolderBasedFileSystemContentStorage(
       { fs, logs: await createLogComponent({}) },
       tmpDir,
-      { decompressCacheMaxSize: 500 }
+      { decompressCacheMaxSize: 5 * 1024 * 1024 * 1024, decompressMaxFileSize: 50 }
     )
     const cachedFilePath = path.join(tmpDir, '9584', id)
 
     try {
-      // 1000 bytes exceeds the inherited 500-byte limit (proving the cap came from
-      // decompressCacheMaxSize, not the multi-GB fallback), so it is refused.
       const data = Buffer.from(new Uint8Array(1000).fill(0))
       await storage.storeStreamAndCompress(id, bufferToStream(data))
 


### PR DESCRIPTION
Follow-up to #101.

## Problem

`decompressMaxFileSize` (the per-file inflation cap added in #101) **defaulted to `decompressCacheMaxSize`** — i.e. the whole-cache budget, 5 GB by default. That conflates two different limits:

- A *single* decompression shouldn't be allowed to consume the entire cache (it fills it and gets evicted on the next cycle — pointless caching).
- 5 GB written per decompression, times concurrent requests, is still a real disk/CPU DoS — which is exactly what the cap is meant to prevent, so a 5 GB default largely defeats it.

## Change

Give the per-file cap its own dedicated default of **256 MB**, independent of `decompressCacheMaxSize`:

```ts
const MAX_DECOMPRESSED_SIZE = options?.decompressMaxFileSize ?? TWO_HUNDRED_FIFTY_SIX_MB_IN_BYTES
```

256 MB is comfortably above any realistic single *compressible* content file — for context a whole world's content budget is ~100 MB (36 MB for ENS), and binary/media (which is what gets large) compresses poorly so it's stored uncompressed and never hits this decompression path at all. Meanwhile it bounds a malicious gzip to ~20× smaller than before. Still fully overridable via the option; raise it if a deployment legitimately serves larger gzipped content.

## Tests

Reworked the two default-cap tests to match the decoupled behaviour:
- With `decompressMaxFileSize` unset and `decompressCacheMaxSize: 500`, a 1000-byte file (larger than the cache budget, far under the 256 MB default) now **decompresses successfully** — proving the per-file cap is no longer inherited from the cache size.
- An explicit `decompressMaxFileSize: 50` still caps decompression even with a 5 GB cache budget — the override path is unaffected.

(The exact 256 MB boundary isn't asserted with a real >256 MB payload — impractical in a unit test — but the cap *mechanism* is already proven by the explicit-small-cap tests.)

Full suite green (`yarn test`): 7 suites, 124 passed.