### PR TITLE
fix: deduplicate concurrent decompressions of the same gzip

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -226,45 +226,49 @@ export async function createFolderBasedFileSystemContentStorage(
       if (!contentItem && range) {
         const uncompressedPath = await getFilePath(id)
 
-        // Wait for any in-flight decompression of the same file, or start one
+        // Deduplicate concurrent decompressions of the same file. The promise is created and
+        // registered synchronously — there is no `await` between the `get` and the `set` — so
+        // simultaneous callers share a single decompression. Otherwise both would pass the
+        // "not in flight" check, write the same cache file concurrently (corrupting it) and
+        // double-count its size against totalCacheSize.
         let decompressPromise = inflightDecompressions.get(uncompressedPath)
         const isOwner = !decompressPromise
         if (!decompressPromise) {
-          const gzipItem = await retrieveWithEncoding(id, 'gzip')
-          if (gzipItem) {
-            decompressPromise = (async () => {
-              try {
-                // Cap how much the gzip may inflate to so a decompression bomb cannot write an
-                // unbounded file to disk. The gzip trailer's declared size is attacker-controllable,
-                // so the limit is enforced on the actual inflated bytes, not a declared value.
-                await pipe(
-                  await gzipItem.asStream(),
-                  createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
-                  components.fs.createWriteStream(uncompressedPath)
-                )
-              } catch (err) {
-                // Remove partial file to prevent serving corrupt data (or a partially-written bomb)
-                await noFailUnlink(uncompressedPath)
-                throw err
-              }
+          decompressPromise = (async () => {
+            const gzipItem = await retrieveWithEncoding(id, 'gzip')
+            if (!gzipItem) {
+              return
+            }
+            try {
+              // Cap how much the gzip may inflate to so a decompression bomb cannot write an
+              // unbounded file to disk. The gzip trailer's declared size is attacker-controllable,
+              // so the limit is enforced on the actual inflated bytes, not a declared value.
+              await pipe(
+                await gzipItem.asStream(),
+                createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
+                components.fs.createWriteStream(uncompressedPath)
+              )
+            } catch (err) {
+              // Remove partial file to prevent serving corrupt data (or a partially-written bomb)
+              await noFailUnlink(uncompressedPath)
+              throw err
+            }
 
-              const stat = await components.fs.stat(uncompressedPath)
-              decompressCache.set(uncompressedPath, { size: stat.size, lastAccess: Date.now() })
-              totalCacheSize += stat.size
-            })()
-            inflightDecompressions.set(uncompressedPath, decompressPromise)
-          }
+            const stat = await components.fs.stat(uncompressedPath)
+            decompressCache.set(uncompressedPath, { size: stat.size, lastAccess: Date.now() })
+            totalCacheSize += stat.size
+          })()
+          inflightDecompressions.set(uncompressedPath, decompressPromise)
         }
-        if (decompressPromise) {
-          try {
-            await decompressPromise
-          } finally {
-            if (isOwner) inflightDecompressions.delete(uncompressedPath)
-          }
 
-          // Serve range from the cached uncompressed file
-          contentItem = await retrieveWithEncoding(id, null, range)
+        try {
+          await decompressPromise
+        } finally {
+          if (isOwner) inflightDecompressions.delete(uncompressedPath)
         }
+
+        // Serve range from the cached uncompressed file (undefined if the gzip didn't exist)
+        contentItem = await retrieveWithEncoding(id, null, range)
       }
 
       return contentItem

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -465,7 +465,9 @@ describe('fileSystemContentStorage', () => {
 
   it(`When many range requests race for the same cold gzip, then it is decompressed only once and all return correct data`, async () => {
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-race-'))
-    const cachedFilePath = path.join(tmpDir, '9584', id)
+    // Derive the shard the same way the storage does, rather than hardcoding the hash prefix.
+    const shard = createHash('sha1').update(id).digest('hex').substring(0, 4)
+    const cachedFilePath = path.join(tmpDir, shard, id)
 
     // Wrap the fs component to count how many times the uncompressed cache file is written.
     // Without deduplication, concurrent cold-cache range requests each decompress it, writing

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -2,7 +2,12 @@ import { createHash } from 'crypto'
 import { mkdtempSync, promises as nodeFs, rmSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { createFolderBasedFileSystemContentStorage, createFsComponent, IContentStorageComponent } from '../src'
+import {
+  createFolderBasedFileSystemContentStorage,
+  createFsComponent,
+  IContentStorageComponent,
+  IFileSystemComponent
+} from '../src'
 import { bufferToStream, streamToBuffer } from '../src'
 import { createLogComponent } from '@well-known-components/logger'
 
@@ -452,6 +457,55 @@ describe('fileSystemContentStorage', () => {
 
       // The partial uncompressed file should have been cleaned up
       expect(await fs.existPath(uncompressedPath)).toBeFalsy()
+    } finally {
+      await storage.stop?.()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it(`When many range requests race for the same cold gzip, then it is decompressed only once and all return correct data`, async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-race-'))
+    const cachedFilePath = path.join(tmpDir, '9584', id)
+
+    // Wrap the fs component to count how many times the uncompressed cache file is written.
+    // Without deduplication, concurrent cold-cache range requests each decompress it, writing
+    // the file once per request (and double-counting its size against the cache budget).
+    const realFs = createFsComponent()
+    let decompressionWrites = 0
+    const spyFs: IFileSystemComponent = {
+      ...realFs,
+      createWriteStream: ((target: any, options?: any) => {
+        if (target === cachedFilePath) decompressionWrites++
+        return realFs.createWriteStream(target, options)
+      }) as typeof realFs.createWriteStream
+    }
+
+    const storage = await createFolderBasedFileSystemContentStorage(
+      { fs: spyFs, logs: await createLogComponent({}) },
+      tmpDir
+    )
+
+    try {
+      const data = Buffer.from('ABCDEFGH'.repeat(200)) // 1600 bytes, compressible
+      await storage.storeStreamAndCompress(id, bufferToStream(data))
+      expect(await realFs.existPath(cachedFilePath)).toBeFalsy() // cold uncompressed cache
+      decompressionWrites = 0 // count only the decompression phase
+
+      const range = { start: 100, end: 199 }
+      const expected = data.subarray(100, 200)
+
+      const results = await Promise.all(
+        Array.from({ length: 16 }, async () => {
+          const item = await storage.retrieve(id, range)
+          return streamToBuffer(await item!.asStream())
+        })
+      )
+
+      for (const buffer of results) {
+        expect(buffer).toEqual(expected)
+      }
+      // Deduplicated: the gzip is decompressed to the cache file exactly once.
+      expect(decompressionWrites).toBe(1)
     } finally {
       await storage.stop?.()
       rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
Found during a bug/correctness re-review of `main`.

## Bug

The decompression cache has an in-flight guard (`inflightDecompressions`) meant to ensure a gzip is decompressed only once even under concurrent range requests. It doesn't work, because the check-and-register straddles an `await`:

```ts
let decompressPromise = inflightDecompressions.get(uncompressedPath)
const isOwner = !decompressPromise
if (!decompressPromise) {
  const gzipItem = await retrieveWithEncoding(id, 'gzip')   // <-- await between get and set
  if (gzipItem) {
    decompressPromise = (async () => { ... totalCacheSize += stat.size })()
    inflightDecompressions.set(uncompressedPath, decompressPromise)
  }
}
```

Two concurrent cold-cache range requests for the same file both read "not in flight", both `await` the gzip lookup, then both register and run a decompression. Consequences:

- **Redundant work** — N concurrent requests run N decompressions instead of 1 (verified: 16 concurrent requests → 16 decompressions).
- **Cache-size accounting drift** — each decompression does `totalCacheSize += stat.size` while `decompressCache.set` keeps a single entry, so the counter is over-incremented by `(N-1) × size`. Eviction later subtracts only one size, leaking the rest into the counter → `totalCacheSize` drifts upward → premature/aggressive eviction (cache thrashing) over time.

(Output isn't corrupted in practice — the concurrent writes are identical content/length so the file converges — so this is a correctness/efficiency bug, not a data-integrity one.)

## Fix

Create and register the promise **synchronously** — no `await` between the `get` and the `set`, with the gzip lookup moved inside the promise — so a concurrent caller sees the in-flight entry and shares it:

```ts
let decompressPromise = inflightDecompressions.get(uncompressedPath)
const isOwner = !decompressPromise
if (!decompressPromise) {
  decompressPromise = (async () => {
    const gzipItem = await retrieveWithEncoding(id, 'gzip')
    if (!gzipItem) return
    try { await pipe(...) } catch (err) { await noFailUnlink(uncompressedPath); throw err }
    const stat = await components.fs.stat(uncompressedPath)
    decompressCache.set(uncompressedPath, { size: stat.size, lastAccess: Date.now() })
    totalCacheSize += stat.size
  })()
  inflightDecompressions.set(uncompressedPath, decompressPromise)
}
try { await decompressPromise } finally { if (isOwner) inflightDecompressions.delete(uncompressedPath) }
contentItem = await retrieveWithEncoding(id, null, range)
```

## Tests

Added a regression test that wraps the fs component to count writes to the uncompressed cache path and fires 16 simultaneous range requests for the same cold gzip. It asserts the file is decompressed **exactly once** (and all 16 return the correct bytes). Verified it fails on the old code (`Received: 16`) and passes with the fix.

Full suite green (`yarn test`): 7 suites, 128 passed.