### PR TITLE
fix: make folder storage start() idempotent

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -345,6 +345,10 @@ export async function createFolderBasedFileSystemContentStorage(
 
   return {
     async start(_startOptions: any) {
+      // Idempotent: clear any existing timer first so a repeated start() doesn't leak intervals.
+      if (evictionTimer) {
+        clearInterval(evictionTimer)
+      }
       evictionTimer = setInterval(evictCache, CACHE_EVICTION_INTERVAL)
       evictionTimer.unref()
     },

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -305,6 +305,28 @@ describe('fileSystemContentStorage', () => {
       jest.useRealTimers()
     })
 
+    it(`When start is called more than once, then it does not schedule a second eviction timer`, async () => {
+      const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-start-'))
+      const storage = await createFolderBasedFileSystemContentStorage(
+        { fs, logs: await createLogComponent({}) },
+        tmpDir,
+        { decompressCacheEvictionInterval: 30000 }
+      )
+
+      try {
+        await storage.start?.({} as any)
+        const timersAfterFirstStart = jest.getTimerCount()
+
+        await storage.start?.({} as any)
+
+        // The repeated start replaces the timer rather than leaking an extra one.
+        expect(jest.getTimerCount()).toBe(timersAfterFirstStart)
+      } finally {
+        await storage.stop?.()
+        rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
     it(`When the cache TTL expires, then the cached uncompressed file is cleaned up`, async () => {
       const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'content-storage-cache-'))
       const storage = await createFolderBasedFileSystemContentStorage(


### PR DESCRIPTION
Minor lifecycle hardening found during the bug re-review.

## Problem

`start()` unconditionally does `evictionTimer = setInterval(...)`. Calling it twice (e.g. a double-wire, or restart-without-stop) schedules a **second** eviction interval and overwrites the reference to the first — leaking a timer that runs for the lifetime of the process.

## Fix

Clear any existing timer before scheduling a new one, making `start()` idempotent:

```ts
async start() {
  if (evictionTimer) {
    clearInterval(evictionTimer)
  }
  evictionTimer = setInterval(evictCache, CACHE_EVICTION_INTERVAL)
  evictionTimer.unref()
}
```

## Tests

Added a test (under fake timers) asserting that a repeated `start()` does not increase the active timer count. Verified it fails on the old code (`Received: 2`) and passes with the fix. Full suite green (`yarn test`): 7 suites, 128 passed.