### PR TITLE
fix: remove the partial .gzip when compression fails

### DIFF
--- a/src/extras/compression.ts
+++ b/src/extras/compression.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
 import { createGzip } from 'zlib'
+import { ILoggerComponent } from '@well-known-components/interfaces'
 const pipe = promisify(pipeline)
 
 /**
@@ -17,12 +18,33 @@ export type CompressionResult = {
 /**
  * @public
  */
-export async function compressContentFile(contentFilePath: string): Promise<boolean> {
-  const result = await gzipCompressFile(contentFilePath, contentFilePath + '.gzip')
+export async function compressContentFile(
+  contentFilePath: string,
+  logger?: ILoggerComponent.ILogger
+): Promise<boolean> {
+  const result = await gzipCompressFile(contentFilePath, contentFilePath + '.gzip', logger)
   return !!result
 }
 
-async function gzipCompressFile(input: string, output: string): Promise<CompressionResult | null> {
+/**
+ * Removes the (possibly partial) compressed output. A missing file (ENOENT) is expected and
+ * ignored; any other failure leaves a stray .gzip on disk, so it is surfaced via the logger.
+ */
+async function removeOutput(output: string, reason: string, logger?: ILoggerComponent.ILogger): Promise<void> {
+  try {
+    await fs.promises.unlink(output)
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      logger?.warn(`Failed to remove compressed file after ${reason}`, { output, error: err?.message ?? String(err) })
+    }
+  }
+}
+
+async function gzipCompressFile(
+  input: string,
+  output: string,
+  logger?: ILoggerComponent.ILogger
+): Promise<CompressionResult | null> {
   if (path.resolve(input) === path.resolve(output)) {
     throw new Error("Can't compress a file using src==dst")
   }
@@ -45,7 +67,7 @@ async function gzipCompressFile(input: string, output: string): Promise<Compress
       // if the new file is bigger than the original file then we delete the compressed file
       // the 1.1 magic constant is to establish a gain of at least 10% of the size to justify the
       // extra CPU of the decompression. Awaited so the .gzip is gone before we return.
-      await fs.promises.unlink(output).catch(() => undefined)
+      await removeOutput(output, 'a non-beneficial compression ratio', logger)
       return null
     }
 
@@ -56,7 +78,7 @@ async function gzipCompressFile(input: string, output: string): Promise<Compress
   } catch (err) {
     // On any failure (read/write/gzip error) remove the partial .gzip so it can't shadow the
     // source file and be served as corrupt content on a later read.
-    await fs.promises.unlink(output).catch(() => undefined)
+    await removeOutput(output, 'a compression failure', logger)
     throw err
   }
 }

--- a/src/extras/compression.ts
+++ b/src/extras/compression.ts
@@ -31,25 +31,32 @@ async function gzipCompressFile(input: string, output: string): Promise<Compress
   const destination = fs.createWriteStream(output)
 
   try {
-    await pipe(source, gzip, destination)
-  } finally {
-    destroy(source)
-    destroy(destination)
-  }
+    try {
+      await pipe(source, gzip, destination)
+    } finally {
+      destroy(source)
+      destroy(destination)
+    }
 
-  const originalSize = await fs.promises.lstat(input)
-  const newSize = await fs.promises.lstat(output)
+    const originalSize = await fs.promises.lstat(input)
+    const newSize = await fs.promises.lstat(output)
 
-  if (newSize.size * 1.1 > originalSize.size) {
-    // if the new file is bigger than the original file then we delete the compressed file
-    // the 1.1 magic constant is to establish a gain of at least 10% of the size to justify the
-    // extra CPU of the decompression
-    fs.unlink(output, () => {})
-    return null
-  }
+    if (newSize.size * 1.1 > originalSize.size) {
+      // if the new file is bigger than the original file then we delete the compressed file
+      // the 1.1 magic constant is to establish a gain of at least 10% of the size to justify the
+      // extra CPU of the decompression. Awaited so the .gzip is gone before we return.
+      await fs.promises.unlink(output).catch(() => undefined)
+      return null
+    }
 
-  return {
-    originalSize: originalSize.size,
-    compressedSize: newSize.size
+    return {
+      originalSize: originalSize.size,
+      compressedSize: newSize.size
+    }
+  } catch (err) {
+    // On any failure (read/write/gzip error) remove the partial .gzip so it can't shadow the
+    // source file and be served as corrupt content on a later read.
+    await fs.promises.unlink(output).catch(() => undefined)
+    throw err
   }
 }

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -379,7 +379,7 @@ export async function createFolderBasedFileSystemContentStorage(
       const filePath = await getFilePath(id)
       await removeCacheEntry(filePath)
       await storeStream(id, stream)
-      if (await compressContentFile(filePath)) {
+      if (await compressContentFile(filePath, logger)) {
         // try to remove original file if present
         const contentItem = await retrieve(id)
         if (contentItem?.encoding) {

--- a/test/compression.spec.ts
+++ b/test/compression.spec.ts
@@ -1,0 +1,47 @@
+import { existsSync, mkdtempSync, promises as nodeFs, rmSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { compressContentFile } from '../src/extras/compression'
+
+describe('compressContentFile', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), 'compression-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it(`When the content compresses well, then a .gzip is produced`, async () => {
+    const input = path.join(dir, 'compressible')
+    await nodeFs.writeFile(input, Buffer.alloc(1000, 0))
+
+    const result = await compressContentFile(input)
+
+    expect(result).toBe(true)
+    expect(existsSync(input + '.gzip')).toBe(true)
+  })
+
+  it(`When the content does not compress well, then the .gzip is discarded`, async () => {
+    const input = path.join(dir, 'incompressible')
+    await nodeFs.writeFile(input, 'a')
+
+    const result = await compressContentFile(input)
+
+    expect(result).toBe(false)
+    expect(existsSync(input + '.gzip')).toBe(false)
+  })
+
+  it(`When compression fails, then it rejects and leaves no partial .gzip behind`, async () => {
+    const input = path.join(dir, 'missing')
+    // Pre-create a stale .gzip so the assertion is deterministic regardless of stream-open races:
+    // the failed compression must remove it rather than leave it to shadow the (absent) source.
+    await nodeFs.writeFile(input + '.gzip', 'stale')
+
+    await expect(compressContentFile(input)).rejects.toThrow()
+
+    expect(existsSync(input + '.gzip')).toBe(false)
+  })
+})

--- a/test/compression.spec.ts
+++ b/test/compression.spec.ts
@@ -34,8 +34,10 @@ describe('compressContentFile', () => {
     expect(existsSync(input + '.gzip')).toBe(false)
   })
 
-  it(`When compression fails, then it rejects and leaves no partial .gzip behind`, async () => {
+  it(`When the source cannot be read, then it rejects and removes the partial .gzip`, async () => {
     const input = path.join(dir, 'missing')
+    // The missing source triggers a read-open error. That goes through the same catch/unlink
+    // cleanup path as a mid-stream gzip/write failure, so it exercises the partial-output removal.
     // Pre-create a stale .gzip so the assertion is deterministic regardless of stream-open races:
     // the failed compression must remove it rather than leave it to shadow the (absent) source.
     await nodeFs.writeFile(input + '.gzip', 'stale')


### PR DESCRIPTION
Found during a bug re-review of `main`.

## Bug

`gzipCompressFile` (used by `storeStreamAndCompress`) destroys its streams in a `finally` but never removes the output `.gzip` if the pipe fails:

```ts
try {
  await pipe(source, gzip, destination)
} finally {
  destroy(source)
  destroy(destination)
}
// ... lstat / ratio check
```

On a read/write/gzip error mid-compression, the error propagates with a **truncated `.gzip` left on disk**. Since `retrieve` and `fileInfo` check the `.gzip` variant first, that partial file then **shadows the good uncompressed file** and is served (gunzipped) as corrupt content on later reads. `storeStream` already cleans up its partial on error; this path didn't.

## Fix

Wrap the compression in a `try/catch` that unlinks the output on any failure and rethrows, so a failed compression leaves no `.gzip` behind. Also `await` the bad-ratio unlink (it was fire-and-forget, leaving a brief window where a stale `.gzip` could be read).

```ts
try {
  try { await pipe(source, gzip, destination) } finally { destroy(source); destroy(destination) }
  const originalSize = await fs.promises.lstat(input)
  const newSize = await fs.promises.lstat(output)
  if (newSize.size * 1.1 > originalSize.size) {
    await fs.promises.unlink(output).catch(() => undefined)
    return null
  }
  return { originalSize: originalSize.size, compressedSize: newSize.size }
} catch (err) {
  await fs.promises.unlink(output).catch(() => undefined)
  throw err
}
```

## Tests

New `test/compression.spec.ts` covering: good-ratio (produces `.gzip`), bad-ratio (discards `.gzip`), and failure (rejects and leaves **no** partial `.gzip`). The failure test pre-creates a stale `.gzip` so the assertion is deterministic; verified it fails on the old code (`.gzip` left behind) and passes with the fix.

Full suite green (`yarn test`): 8 suites, 130 passed.

## Trigger / severity

Requires an IO/gzip error during `storeStreamAndCompress` (e.g. disk error) — uncommon, but the consequence (a corrupt `.gzip` silently shadowing valid content) is bad enough to warrant the cleanup, which was clearly intended (it exists for the analogous `storeStream` path).