### PR TITLE
fix: make S3 retrieve error logging actionable

### DIFF
--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -164,8 +164,23 @@ export async function createS3BasedFileSystemContentStorage(
       )
     } catch (error: any) {
       if (error instanceof RangeError) throw error
+      // A missing object returns NotFound (404) when the principal has s3:ListBucket; there is
+      // nothing to serve, so fall through and return undefined.
       if (error.code !== 'NotFound') {
-        logger.error(error)
+        const logContext = { key: getKey(id), code: error.code, statusCode: error.statusCode }
+        if (error.statusCode === 403) {
+          // S3 returns 403 (with an empty body, hence a null message on HEAD) instead of 404 for a
+          // missing key when the principal lacks s3:ListBucket. It can also be a genuine access
+          // denial. Surface it as an actionable warning rather than a bare, message-less error.
+          logger.warn(
+            'S3 returned 403 Forbidden retrieving content; returning not-found. If the object is simply missing, grant the principal s3:ListBucket so missing keys return 404; otherwise check the object/bucket permissions.',
+            logContext
+          )
+        } else {
+          logger.error(`Failed to retrieve content from S3: ${error.message || error.code || 'unknown error'}`, {
+            ...logContext
+          })
+        }
       }
     }
     return undefined

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -177,9 +177,10 @@ export async function createS3BasedFileSystemContentStorage(
             logContext
           )
         } else {
-          logger.error(`Failed to retrieve content from S3: ${error.message || error.code || 'unknown error'}`, {
-            ...logContext
-          })
+          logger.error(
+            `Failed to retrieve content from S3: ${error.message || error.code || 'unknown error'}`,
+            logContext
+          )
         }
       }
     }

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -343,3 +343,56 @@ describe('S3 Storage edge cases', () => {
     expect(source.destroyed).toBe(true)
   })
 })
+
+describe('S3 Storage retrieve error logging', () => {
+  function createSpyLogs() {
+    const logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    return { logs: { getLogger: () => logger }, logger }
+  }
+
+  async function retrieveWithHeadError(headError: any) {
+    const { logs, logger } = createSpyLogs()
+    const mockS3 = {
+      headObject: jest.fn().mockReturnValue({ promise: () => Promise.reject(headError) }),
+      getObject: jest.fn(),
+      upload: jest.fn(),
+      deleteObjects: jest.fn(),
+      listObjectsV2: jest.fn()
+    }
+    const storage = await createS3BasedFileSystemContentStorage({ logs } as any, mockS3 as any, { Bucket: 'test' })
+    const result = await storage.retrieve('some-key')
+    return { result, logger }
+  }
+
+  it(`When headObject returns 403 Forbidden, then it warns with the key and does not error`, async () => {
+    const { result, logger } = await retrieveWithHeadError(
+      Object.assign(new Error(), { code: 'Forbidden', statusCode: 403 })
+    )
+
+    expect(result).toBeUndefined()
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn.mock.calls[0][1]).toMatchObject({ key: 'some-key', statusCode: 403 })
+  })
+
+  it(`When headObject returns NotFound, then it logs nothing and returns undefined`, async () => {
+    const { result, logger } = await retrieveWithHeadError(
+      Object.assign(new Error(), { code: 'NotFound', statusCode: 404 })
+    )
+
+    expect(result).toBeUndefined()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it(`When headObject fails with a non-403 error, then it logs an error with the key`, async () => {
+    const { result, logger } = await retrieveWithHeadError(
+      Object.assign(new Error('boom'), { code: 'InternalError', statusCode: 500 })
+    )
+
+    expect(result).toBeUndefined()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    expect(logger.error.mock.calls[0][1]).toMatchObject({ key: 'some-key', code: 'InternalError' })
+  })
+})


### PR DESCRIPTION
## Problem

A production error surfaced as:

```
[ERROR] (s3-based-content-storage): Forbidden: null
... statusCode: 403, code: "Forbidden" ... at Request.extractError (.../services/s3.js)
```

`retrieve()` calls `s3.headObject` first and, in the catch, logs any non-`NotFound` error as a bare `logger.error(error)`. For a 403 on a HEAD request the body is empty, so the message is `null` → the log reads "Forbidden: null" with **no indication of which key failed** and no guidance.

A 403 (rather than 404) for a key typically means the principal lacks `s3:ListBucket` (so S3 won't reveal a missing object's absence and returns Forbidden), or it's a genuine access denial.

## Change

`retrieve` now, for non-`NotFound` errors:
- includes the failing **key** plus the S3 `code`/`statusCode` in the log context, and
- logs **403 as a `warn`** with an actionable hint (grant `s3:ListBucket` so missing keys 404, otherwise check object/bucket permissions) instead of a message-less `error`; other errors keep logging at `error` but with a real message + the key.

Behavior is otherwise unchanged — `retrieve` still returns `undefined`.

## Tests

Added a `retrieve error logging` suite (spy logger): a 403 warns with the key and does not error; a `NotFound` logs nothing; a non-403 error logs an error with the key. Full suite green (`yarn test`): 8 suites, 135 passed.