### PR TITLE
feat: support cancellation signals in storeStream and storeStreamAndCompress

### DIFF
--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -59,7 +59,12 @@ function isAbortTeardownError(error: unknown, signal: AbortSignal, teardown: Tea
   if (error === signal.reason) return true
   const err = error as { name?: unknown; code?: unknown } | null
   if (teardown.destroyedSource && err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
-  // aws-sdk v2 ManagedUpload.abort()
+  // aws-sdk v2 ManagedUpload.abort(). NOTE for a future v3 migration (v3 was tried in #66 and
+  // rolled back in #74): v3 rejects aborted requests with an `AbortError` from @smithy, a shape this
+  // function deliberately does NOT credit — a custom transport can raise one coincidentally. A v3
+  // port must therefore attribute the abort where it is known, as the compression pipeline does at
+  // its call site (or rely on v3's native `abortSignal` request option), or cancelled uploads will
+  // surface as raw abort errors instead of the caller's reason.
   if (teardown.abortedTransport && (err?.code === 'RequestAbortedError' || err?.name === 'RequestAbortedError')) {
     return true
   }

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -1,5 +1,31 @@
 import { Readable } from 'stream'
 
+const NON_CANCELLATION_ERROR = Symbol('nonCancellationError')
+
+/**
+ * Marks an error as NOT being a consequence of cancellation, so `runStoreWithSignal` surfaces it
+ * as-is even when the signal has aborted. Backends use this for irreversible commit/cleanup-phase
+ * failures (e.g. a committed-but-unreconciled storage state): those are never caused by abort
+ * teardown — the source is fully consumed before the commit begins — and masking them behind the
+ * cancellation reason would hide the repair/quarantine signal from callers and operators.
+ * The marker preserves the error's identity and class, only tagging it.
+ */
+export function markAsNonCancellationError<T>(error: T): T {
+  if (error !== null && typeof error === 'object') {
+    try {
+      Object.defineProperty(error, NON_CANCELLATION_ERROR, { value: true, enumerable: false })
+    } catch {
+      // A frozen/sealed error cannot be tagged; it may then be translated on abort — acceptable
+      // degradation, and no storage code throws frozen errors.
+    }
+  }
+  return error
+}
+
+function isNonCancellationError(error: unknown): boolean {
+  return error !== null && typeof error === 'object' && NON_CANCELLATION_ERROR in error
+}
+
 function abortReasonOf(signal: AbortSignal): unknown {
   // `??` would also replace an explicit `null` abort reason; the caller must observe their own
   // cancellation cause, so only default when no reason was provided at all.
@@ -56,7 +82,10 @@ export async function runStoreWithSignal<T>(
   try {
     return await operation()
   } catch (error) {
-    throw signal.aborted ? abortReasonOf(signal) : error
+    // Translate teardown-caused rejections (destroyed source, aborted transport) to the caller's
+    // cancellation reason — but NEVER errors marked as commit/cleanup-phase failures: those carry
+    // repair/quarantine information that the abort did not cause and must not hide.
+    throw signal.aborted && !isNonCancellationError(error) ? abortReasonOf(signal) : error
   } finally {
     signal.removeEventListener('abort', abort)
   }

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -37,23 +37,32 @@ export function isAbortError(error: unknown): boolean {
   return err?.name === 'AbortError' || err?.code === 'ABORT_ERR'
 }
 
+/** What this run's abort teardown actually did, used to prove a rejection was caused by it. */
+type TeardownProvenance = {
+  /** The listener destroyed a source that was still live (a destroy on a dead stream is a no-op). */
+  destroyedSource: boolean
+  /** The `onAbort` hook reported tearing down in-flight transport (e.g. an S3 managed upload). */
+  abortedTransport: boolean
+}
+
 /**
- * True only for rejections provably produced by this module's abort teardown: the signal's own
- * reason (checkpoint throws), abort errors (signalled pipelines, `throwIfAborted` defaults), a
- * prematurely closed stream — but ONLY when this run's teardown actually destroyed the live source
- * (`ERR_STREAM_PREMATURE_CLOSE` is a public shape: a source can close prematurely for a real
- * upstream fault and then race the abort, and that failure must surface as itself) — or an aborted
- * S3 managed upload (`RequestAbortedError` only arises from `ManagedUpload.abort()`, which nothing
- * but this module's hook calls on these uploads). Anything else — fs, zlib, transport or logic
- * errors that merely raced the abort — is NOT teardown-caused and must surface as itself.
+ * True only for rejections provably produced by this module's abort teardown. Both stream and
+ * transport shapes are public — a source can close prematurely, and an SDK can report an aborted
+ * request, for reasons of their own that merely race the cancellation — so each is credited only
+ * when this run's teardown actually performed the corresponding action. The signal's own reason and
+ * abort errors need no provenance: they can only come from our checkpoints or a signalled pipeline.
+ * Anything else — fs, zlib, transport or logic errors — is NOT teardown-caused and surfaces as
+ * itself.
  */
-function isAbortTeardownError(error: unknown, signal: AbortSignal, teardownDestroyedSource: boolean): boolean {
+function isAbortTeardownError(error: unknown, signal: AbortSignal, teardown: TeardownProvenance): boolean {
   if (error === signal.reason) return true
   if (isAbortError(error)) return true
   const err = error as { name?: unknown; code?: unknown } | null
-  if (teardownDestroyedSource && err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
+  if (teardown.destroyedSource && err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
   // aws-sdk v2 ManagedUpload.abort()
-  if (err?.code === 'RequestAbortedError' || err?.name === 'RequestAbortedError') return true
+  if (teardown.abortedTransport && (err?.code === 'RequestAbortedError' || err?.name === 'RequestAbortedError')) {
+    return true
+  }
   return false
 }
 
@@ -68,7 +77,9 @@ function abortReasonOf(signal: AbortSignal): unknown {
  *
  * On abort the source stream is destroyed — settling any consumer awaiting its data — and the
  * optional `onAbort` hook runs so callers can tear down transport that no longer depends on the
- * source (e.g. an S3 managed upload whose remaining parts are already buffered). A rejection that
+ * source (e.g. an S3 managed upload whose remaining parts are already buffered); the hook returns
+ * `true` when it actually tore something down, which is what lets a transport-shaped rejection be
+ * credited to this cancellation rather than to a coincident fault. A rejection that
  * is provably caused by that teardown is surfaced as the signal's reason, so callers observe their
  * own cancellation cause rather than a transport-specific error; a rejection that merely RACED the
  * abort (fs, zlib, transport or logic failures) surfaces as itself — cancellation must never mask
@@ -83,7 +94,7 @@ export async function runStoreWithSignal<T>(
   stream: Readable,
   signal: AbortSignal | undefined,
   operation: () => Promise<T>,
-  onAbort?: () => void
+  onAbort?: () => boolean | void
 ): Promise<T> {
   if (!signal) {
     return operation()
@@ -96,25 +107,25 @@ export async function runStoreWithSignal<T>(
     }
     throw abortReasonOf(signal)
   }
-  // Whether THIS run's teardown destroyed a live source. A premature-close rejection is only
-  // provably ours when it did: if the source was already dead (ended, or destroyed by a real
-  // upstream fault) when the abort fired, our destroy was a no-op and a premature-close failure
-  // belongs to that fault, not to the cancellation.
-  let teardownDestroyedSource = false
+  // What this run's teardown actually did. A premature-close or aborted-transport rejection is only
+  // provably ours when the corresponding action happened: if the source was already dead (ended, or
+  // destroyed by a real upstream fault), or the hook never tore any transport down, a rejection with
+  // that shape belongs to the underlying fault, not to the cancellation.
+  const teardown: TeardownProvenance = { destroyedSource: false, abortedTransport: false }
   const abort = (): void => {
     // Exception-safe: this runs inside the signal's event dispatch, where a throw would escape as
     // an uncaught exception — and a failing stream teardown must not prevent the backend hook from
     // running (nor vice versa). The operation's rejection path owns error reporting.
     try {
       if (!stream.destroyed) {
-        teardownDestroyedSource = true
+        teardown.destroyedSource = true
         stream.destroy()
       }
     } catch {
       // best-effort
     }
     try {
-      onAbort?.()
+      teardown.abortedTransport = onAbort?.() === true
     } catch {
       // best-effort
     }
@@ -129,9 +140,7 @@ export async function runStoreWithSignal<T>(
     // error, a source that closed prematurely on its own — surface as themselves; the marker check
     // is a hard override guaranteeing commit-phase errors are never translated even if one ever
     // matched a teardown shape.
-    throw signal.aborted &&
-      isAbortTeardownError(error, signal, teardownDestroyedSource) &&
-      !isNonCancellationError(error)
+    throw signal.aborted && isAbortTeardownError(error, signal, teardown) && !isNonCancellationError(error)
       ? abortReasonOf(signal)
       : error
   } finally {

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -40,16 +40,18 @@ export function isAbortError(error: unknown): boolean {
 /**
  * True only for rejections provably produced by this module's abort teardown: the signal's own
  * reason (checkpoint throws), abort errors (signalled pipelines, `throwIfAborted` defaults), a
- * prematurely closed stream (the destroyed source — including {@link streamToBuffer}'s close
- * rejection, which carries the same code), or an aborted S3 managed upload. Anything else — fs,
- * zlib, transport or logic errors that merely raced the abort — is NOT teardown-caused and must
- * surface as itself.
+ * prematurely closed stream — but ONLY when this run's teardown actually destroyed the live source
+ * (`ERR_STREAM_PREMATURE_CLOSE` is a public shape: a source can close prematurely for a real
+ * upstream fault and then race the abort, and that failure must surface as itself) — or an aborted
+ * S3 managed upload (`RequestAbortedError` only arises from `ManagedUpload.abort()`, which nothing
+ * but this module's hook calls on these uploads). Anything else — fs, zlib, transport or logic
+ * errors that merely raced the abort — is NOT teardown-caused and must surface as itself.
  */
-function isAbortTeardownError(error: unknown, signal: AbortSignal): boolean {
+function isAbortTeardownError(error: unknown, signal: AbortSignal, teardownDestroyedSource: boolean): boolean {
   if (error === signal.reason) return true
   if (isAbortError(error)) return true
   const err = error as { name?: unknown; code?: unknown } | null
-  if (err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
+  if (teardownDestroyedSource && err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
   // aws-sdk v2 ManagedUpload.abort()
   if (err?.code === 'RequestAbortedError' || err?.name === 'RequestAbortedError') return true
   return false
@@ -94,12 +96,20 @@ export async function runStoreWithSignal<T>(
     }
     throw abortReasonOf(signal)
   }
+  // Whether THIS run's teardown destroyed a live source. A premature-close rejection is only
+  // provably ours when it did: if the source was already dead (ended, or destroyed by a real
+  // upstream fault) when the abort fired, our destroy was a no-op and a premature-close failure
+  // belongs to that fault, not to the cancellation.
+  let teardownDestroyedSource = false
   const abort = (): void => {
     // Exception-safe: this runs inside the signal's event dispatch, where a throw would escape as
     // an uncaught exception — and a failing stream teardown must not prevent the backend hook from
     // running (nor vice versa). The operation's rejection path owns error reporting.
     try {
-      stream.destroy()
+      if (!stream.destroyed) {
+        teardownDestroyedSource = true
+        stream.destroy()
+      }
     } catch {
       // best-effort
     }
@@ -116,9 +126,12 @@ export async function runStoreWithSignal<T>(
     // Translate ONLY rejections provably caused by the abort teardown (destroyed source, aborted
     // transport, checkpoint throws) to the caller's cancellation reason. Real backend/storage
     // failures that merely raced the abort — an S3 rejection, ENOSPC on a staged write, a zlib
-    // error — surface as themselves; the marker check is a hard override guaranteeing commit-phase
-    // errors are never translated even if one ever matched a teardown shape.
-    throw signal.aborted && isAbortTeardownError(error, signal) && !isNonCancellationError(error)
+    // error, a source that closed prematurely on its own — surface as themselves; the marker check
+    // is a hard override guaranteeing commit-phase errors are never translated even if one ever
+    // matched a teardown shape.
+    throw signal.aborted &&
+      isAbortTeardownError(error, signal, teardownDestroyedSource) &&
+      !isNonCancellationError(error)
       ? abortReasonOf(signal)
       : error
   } finally {

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -46,17 +46,17 @@ type TeardownProvenance = {
 }
 
 /**
- * True only for rejections provably produced by this module's abort teardown. Both stream and
- * transport shapes are public — a source can close prematurely, and an SDK can report an aborted
- * request, for reasons of their own that merely race the cancellation — so each is credited only
- * when this run's teardown actually performed the corresponding action. The signal's own reason and
- * abort errors need no provenance: they can only come from our checkpoints or a signalled pipeline.
- * Anything else — fs, zlib, transport or logic errors — is NOT teardown-caused and surfaces as
- * itself.
+ * True only for rejections provably produced by this module's abort teardown. Every shape a store
+ * can reject with is public — a source can close prematurely, an SDK can report an aborted request,
+ * a custom stream or transport can raise an `AbortError` of its own — so no shape is credited on
+ * appearance alone. The signal's own reason needs no provenance (only our checkpoints throw it, and
+ * the one place that hands a signal to an abortable pipeline converts that pipeline's abort into the
+ * reason at its call site, where the attribution is known); the remaining shapes are credited only
+ * when this run's teardown actually performed the corresponding action. Anything else — fs, zlib,
+ * transport or logic errors — is NOT teardown-caused and surfaces as itself.
  */
 function isAbortTeardownError(error: unknown, signal: AbortSignal, teardown: TeardownProvenance): boolean {
   if (error === signal.reason) return true
-  if (isAbortError(error)) return true
   const err = error as { name?: unknown; code?: unknown } | null
   if (teardown.destroyedSource && err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
   // aws-sdk v2 ManagedUpload.abort()

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -118,7 +118,11 @@ export async function runStoreWithSignal<T>(
     // running (nor vice versa). The operation's rejection path owns error reporting.
     try {
       if (!stream.destroyed) {
-        teardown.destroyedSource = true
+        // Only a destroy that interrupts a source still delivering data can cause a premature
+        // close. Destroying one that has already emitted 'end' (reachable with `autoDestroy: false`,
+        // or in the tick before an auto-destroy lands) is just resource cleanup and earns no
+        // provenance — otherwise a premature-close rejection from elsewhere would be credited to us.
+        teardown.destroyedSource = !stream.readableEnded
         stream.destroy()
       }
     } catch {

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -1,7 +1,9 @@
 import { Readable } from 'stream'
 
 function abortReasonOf(signal: AbortSignal): unknown {
-  return signal.reason ?? new Error('The store operation was aborted.')
+  // `??` would also replace an explicit `null` abort reason; the caller must observe their own
+  // cancellation cause, so only default when no reason was provided at all.
+  return signal.reason === undefined ? new Error('The store operation was aborted.') : signal.reason
 }
 
 /**
@@ -28,12 +30,27 @@ export async function runStoreWithSignal<T>(
     return operation()
   }
   if (signal.aborted) {
-    stream.destroy()
+    try {
+      stream.destroy()
+    } catch {
+      // teardown is best-effort; the abort reason below must win
+    }
     throw abortReasonOf(signal)
   }
   const abort = (): void => {
-    stream.destroy()
-    onAbort?.()
+    // Exception-safe: this runs inside the signal's event dispatch, where a throw would escape as
+    // an uncaught exception — and a failing stream teardown must not prevent the backend hook from
+    // running (nor vice versa). The operation's rejection path owns error reporting.
+    try {
+      stream.destroy()
+    } catch {
+      // best-effort
+    }
+    try {
+      onAbort?.()
+    } catch {
+      // best-effort
+    }
   }
   signal.addEventListener('abort', abort, { once: true })
   try {

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -26,6 +26,17 @@ function isNonCancellationError(error: unknown): boolean {
   return error !== null && typeof error === 'object' && NON_CANCELLATION_ERROR in error
 }
 
+/**
+ * True for the rejection shape a signalled `stream/promises` pipeline (or `throwIfAborted`)
+ * produces on abort. Used to distinguish an abort-caused teardown from a real failure that merely
+ * RACED the abort (ENOSPC, EACCES, zlib errors, …): only the former may be suppressed or
+ * reinterpreted as a cancellation outcome.
+ */
+export function isAbortError(error: unknown): boolean {
+  const err = error as { name?: unknown; code?: unknown } | null
+  return err?.name === 'AbortError' || err?.code === 'ABORT_ERR'
+}
+
 function abortReasonOf(signal: AbortSignal): unknown {
   // `??` would also replace an explicit `null` abort reason; the caller must observe their own
   // cancellation cause, so only default when no reason was provided at all.

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -37,6 +37,24 @@ export function isAbortError(error: unknown): boolean {
   return err?.name === 'AbortError' || err?.code === 'ABORT_ERR'
 }
 
+/**
+ * True only for rejections provably produced by this module's abort teardown: the signal's own
+ * reason (checkpoint throws), abort errors (signalled pipelines, `throwIfAborted` defaults), a
+ * prematurely closed stream (the destroyed source — including {@link streamToBuffer}'s close
+ * rejection, which carries the same code), or an aborted S3 managed upload. Anything else — fs,
+ * zlib, transport or logic errors that merely raced the abort — is NOT teardown-caused and must
+ * surface as itself.
+ */
+function isAbortTeardownError(error: unknown, signal: AbortSignal): boolean {
+  if (error === signal.reason) return true
+  if (isAbortError(error)) return true
+  const err = error as { name?: unknown; code?: unknown } | null
+  if (err?.code === 'ERR_STREAM_PREMATURE_CLOSE') return true
+  // aws-sdk v2 ManagedUpload.abort()
+  if (err?.code === 'RequestAbortedError' || err?.name === 'RequestAbortedError') return true
+  return false
+}
+
 function abortReasonOf(signal: AbortSignal): unknown {
   // `??` would also replace an explicit `null` abort reason; the caller must observe their own
   // cancellation cause, so only default when no reason was provided at all.
@@ -48,10 +66,12 @@ function abortReasonOf(signal: AbortSignal): unknown {
  *
  * On abort the source stream is destroyed — settling any consumer awaiting its data — and the
  * optional `onAbort` hook runs so callers can tear down transport that no longer depends on the
- * source (e.g. an S3 managed upload whose remaining parts are already buffered). The operation's
- * rejection is then surfaced as the signal's reason, so callers observe their own cancellation
- * cause rather than a transport-specific error. A store that completes before consuming the abort
- * is allowed to succeed: content is addressed by its id, so a committed write is never harmful.
+ * source (e.g. an S3 managed upload whose remaining parts are already buffered). A rejection that
+ * is provably caused by that teardown is surfaced as the signal's reason, so callers observe their
+ * own cancellation cause rather than a transport-specific error; a rejection that merely RACED the
+ * abort (fs, zlib, transport or logic failures) surfaces as itself — cancellation must never mask
+ * a real storage error. A store that completes before consuming the abort is allowed to succeed:
+ * content is addressed by its id, so a committed write is never harmful.
  *
  * The source is destroyed without an error: consumers observe a premature close, and an
  * already-ended (fully consumed) source is left untouched instead of emitting an 'error' that
@@ -93,10 +113,14 @@ export async function runStoreWithSignal<T>(
   try {
     return await operation()
   } catch (error) {
-    // Translate teardown-caused rejections (destroyed source, aborted transport) to the caller's
-    // cancellation reason — but NEVER errors marked as commit/cleanup-phase failures: those carry
-    // repair/quarantine information that the abort did not cause and must not hide.
-    throw signal.aborted && !isNonCancellationError(error) ? abortReasonOf(signal) : error
+    // Translate ONLY rejections provably caused by the abort teardown (destroyed source, aborted
+    // transport, checkpoint throws) to the caller's cancellation reason. Real backend/storage
+    // failures that merely raced the abort — an S3 rejection, ENOSPC on a staged write, a zlib
+    // error — surface as themselves; the marker check is a hard override guaranteeing commit-phase
+    // errors are never translated even if one ever matched a teardown shape.
+    throw signal.aborted && isAbortTeardownError(error, signal) && !isNonCancellationError(error)
+      ? abortReasonOf(signal)
+      : error
   } finally {
     signal.removeEventListener('abort', abort)
   }

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -1,0 +1,46 @@
+import { Readable } from 'stream'
+
+function abortReasonOf(signal: AbortSignal): unknown {
+  return signal.reason ?? new Error('The store operation was aborted.')
+}
+
+/**
+ * Runs a store operation under an optional cancellation signal.
+ *
+ * On abort the source stream is destroyed — settling any consumer awaiting its data — and the
+ * optional `onAbort` hook runs so callers can tear down transport that no longer depends on the
+ * source (e.g. an S3 managed upload whose remaining parts are already buffered). The operation's
+ * rejection is then surfaced as the signal's reason, so callers observe their own cancellation
+ * cause rather than a transport-specific error. A store that completes before consuming the abort
+ * is allowed to succeed: content is addressed by its id, so a committed write is never harmful.
+ *
+ * The source is destroyed without an error: consumers observe a premature close, and an
+ * already-ended (fully consumed) source is left untouched instead of emitting an 'error' that
+ * may no longer have observers.
+ */
+export async function runStoreWithSignal<T>(
+  stream: Readable,
+  signal: AbortSignal | undefined,
+  operation: () => Promise<T>,
+  onAbort?: () => void
+): Promise<T> {
+  if (!signal) {
+    return operation()
+  }
+  if (signal.aborted) {
+    stream.destroy()
+    throw abortReasonOf(signal)
+  }
+  const abort = (): void => {
+    stream.destroy()
+    onAbort?.()
+  }
+  signal.addEventListener('abort', abort, { once: true })
+  try {
+    return await operation()
+  } catch (error) {
+    throw signal.aborted ? abortReasonOf(signal) : error
+  } finally {
+    signal.removeEventListener('abort', abort)
+  }
+}

--- a/src/content-item.ts
+++ b/src/content-item.ts
@@ -65,7 +65,10 @@ export function streamToBuffer(stream: Readable): Promise<Buffer> {
     stream.on('end', () => resolve(Buffer.concat(buffers)))
     // A stream destroyed without an error emits neither 'end' nor 'error' — only 'close'. Without
     // this the returned promise would never settle. On the graceful path 'close' arrives after
-    // 'end'/'error', where this rejection is a no-op.
-    stream.on('close', () => reject(new Error('Stream closed before it ended.')))
+    // 'end'/'error', where this rejection is a no-op. Carries the standard premature-close code so
+    // cancellation handling can recognize it as teardown-caused rather than a real failure.
+    stream.on('close', () =>
+      reject(Object.assign(new Error('Stream closed before it ended.'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))
+    )
   })
 }

--- a/src/content-item.ts
+++ b/src/content-item.ts
@@ -53,22 +53,33 @@ export function bufferToStream(buffer: Uint8Array | Buffer): Readable {
 export function streamToBuffer(stream: Readable): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const buffers: Uint8Array[] = []
-    stream.on('error', reject)
+    // Tracks settlement so the 'close' fallback below costs nothing on the graceful path: 'close'
+    // always follows 'end'/'error', and building its error unconditionally captured a stack on
+    // EVERY call — the dominant cost of this helper — only to reject an already-settled promise.
+    let settled = false
+    stream.on('error', (error) => {
+      settled = true
+      reject(error)
+    })
     stream.on('data', (data) => {
       if (data instanceof Uint8Array || Buffer.isBuffer(data)) {
         buffers.push(data)
       } else {
+        settled = true
         reject(new Error('Stream did not emit Uint8Array'))
         stream.destroy()
       }
     })
-    stream.on('end', () => resolve(Buffer.concat(buffers)))
+    stream.on('end', () => {
+      settled = true
+      resolve(Buffer.concat(buffers))
+    })
     // A stream destroyed without an error emits neither 'end' nor 'error' — only 'close'. Without
-    // this the returned promise would never settle. On the graceful path 'close' arrives after
-    // 'end'/'error', where this rejection is a no-op. Carries the standard premature-close code so
+    // this the returned promise would never settle. Carries the standard premature-close code so
     // cancellation handling can recognize it as teardown-caused rather than a real failure.
-    stream.on('close', () =>
+    stream.on('close', () => {
+      if (settled) return
       reject(Object.assign(new Error('Stream closed before it ended.'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))
-    )
+    })
   })
 }

--- a/src/content-item.ts
+++ b/src/content-item.ts
@@ -63,5 +63,9 @@ export function streamToBuffer(stream: Readable): Promise<Buffer> {
       }
     })
     stream.on('end', () => resolve(Buffer.concat(buffers)))
+    // A stream destroyed without an error emits neither 'end' nor 'error' — only 'close'. Without
+    // this the returned promise would never settle. On the graceful path 'close' arrives after
+    // 'end'/'error', where this rejection is a no-op.
+    stream.on('close', () => reject(new Error('Stream closed before it ended.')))
   })
 }

--- a/src/extras/compression.ts
+++ b/src/extras/compression.ts
@@ -1,11 +1,9 @@
 import destroy from 'destroy'
 import * as fs from 'fs'
 import * as path from 'path'
-import { pipeline } from 'stream'
-import { promisify } from 'util'
+import { pipeline } from 'stream/promises'
 import { createGzip } from 'zlib'
 import { ILoggerComponent } from '@well-known-components/interfaces'
-const pipe = promisify(pipeline)
 
 /**
  * @public
@@ -21,7 +19,8 @@ export type CompressionResult = {
 export async function compressContentFile(
   contentFilePath: string,
   logger?: ILoggerComponent.ILogger,
-  output?: string
+  output?: string,
+  signal?: AbortSignal
 ): Promise<boolean> {
   // NOTE: compression operates through native node `fs` on LOCAL filesystem paths, not through the
   // injected IFileSystemComponent — custom adapters that virtualize paths get atomic raw writes but
@@ -29,7 +28,10 @@ export async function compressContentFile(
   // `output` lets callers stage the compressed file elsewhere (e.g. a temp dir) and rename it into
   // place themselves, so a process killed mid-compression cannot leave a partial .gzip at the
   // canonical path. Defaults to the in-place `<contentFilePath>.gzip` for backward compatibility.
-  const result = await gzipCompressFile(contentFilePath, output ?? contentFilePath + '.gzip', logger)
+  // `signal` aborts the read→gzip→write pipeline mid-flight (tearing its streams down) instead of
+  // letting a cancelled request keep paying CPU/disk until the compression completes; the partial
+  // output is removed before the rejection propagates.
+  const result = await gzipCompressFile(contentFilePath, output ?? contentFilePath + '.gzip', logger, signal)
   return !!result
 }
 
@@ -50,7 +52,8 @@ async function removeOutput(output: string, reason: string, logger?: ILoggerComp
 async function gzipCompressFile(
   input: string,
   output: string,
-  logger?: ILoggerComponent.ILogger
+  logger?: ILoggerComponent.ILogger,
+  signal?: AbortSignal
 ): Promise<CompressionResult | null> {
   if (path.resolve(input) === path.resolve(output)) {
     throw new Error("Can't compress a file using src==dst")
@@ -61,7 +64,13 @@ async function gzipCompressFile(
 
   try {
     try {
-      await pipe(source, gzip, destination)
+      // This @types/node version requires `signal` in PipelineOptions, so branch instead of
+      // passing an options object without one.
+      if (signal) {
+        await pipeline(source, gzip, destination, { signal })
+      } else {
+        await pipeline(source, gzip, destination)
+      }
     } finally {
       destroy(source)
       destroy(destination)

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -570,12 +570,16 @@ export async function createFolderBasedFileSystemContentStorage(
     stream: Readable,
     signal?: AbortSignal
   ): Promise<void> {
+    // Cancellation is only honored BEFORE the destructive in-place write begins — outside the
+    // rollback path below, since nothing has been touched yet. Once the pipe has replaced the
+    // canonical raw, the previous version is already gone (in-place semantics): an abort observed
+    // after that point treats the store as completed, because "rolling back" would unlink the only
+    // committed object rather than restore anything. A mid-write abort destroys the source, and the
+    // resulting pipe failure follows this mode's usual non-atomic handling (the partial overwrite
+    // is removed; the previous raw version cannot be preserved without rename support).
+    signal?.throwIfAborted()
     try {
       await pipe(stream, components.fs.createWriteStream(filePath))
-      // An abort observed once the source is consumed must still cancel the store: without this
-      // checkpoint the in-place write would be committed for a cancelled request. Throwing here
-      // rolls back through the catch below, so nothing is stored.
-      signal?.throwIfAborted()
       await noFailUnlink(filePath + '.gzip')
       if (await existsForInvariant(filePath + '.gzip')) {
         throw new Error(
@@ -756,6 +760,11 @@ export async function createFolderBasedFileSystemContentStorage(
       // commit; the catch below removes the staged file and the canonical path stays untouched.
       signal?.throwIfAborted()
       await withPathLock(filePath, async () => {
+        // Re-check INSIDE the lock: an abort landing while this store was queued on the path lock
+        // (after the checkpoint above, with the source already consumed) must still cancel before
+        // the irreversible commit below. Nothing has touched the canonical paths yet, so throwing
+        // here is handled exactly like the pre-lock throw.
+        signal?.throwIfAborted()
         try {
           // The raw and its .gzip are one versioned object: a gzip left from a previous version
           // would be preferred by retrieve() and serve stale bytes over the content just stored
@@ -1124,6 +1133,11 @@ export async function createFolderBasedFileSystemContentStorage(
       const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath)
       signal?.throwIfAborted()
       await withPathLock(filePath, async () => {
+        // Re-check INSIDE the lock: an abort landing while this store was queued on the path lock
+        // (after the checkpoints above, with the source already consumed) must still cancel before
+        // the irreversible commit below. Nothing has touched the canonical paths yet, so throwing
+        // here is handled exactly like the pre-lock throws.
+        signal?.throwIfAborted()
         try {
           // Intent-journaled: a crash between the commit rename and the counterpart cleanup is
           // reconciled at next construction, never leaving mixed versions for reads to prefer.

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -503,10 +503,11 @@ export async function createFolderBasedFileSystemContentStorage(
     stagedPath: string,
     primaryPath: string,
     counterpartPath: string,
-    rename: (from: string, to: string) => Promise<void>
+    rename: (from: string, to: string) => Promise<void>,
+    signal?: AbortSignal
   ): Promise<void> {
     try {
-      await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename)
+      await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename, signal)
     } catch (err) {
       // Nothing inside the commit phase can be caused by abort teardown (the source is fully
       // consumed before any commit begins, and the folder backend has no abort hook), so every
@@ -522,7 +523,8 @@ export async function createFolderBasedFileSystemContentStorage(
     stagedPath: string,
     primaryPath: string,
     counterpartPath: string,
-    rename: (from: string, to: string) => Promise<void>
+    rename: (from: string, to: string) => Promise<void>,
+    signal?: AbortSignal
   ): Promise<void> {
     // A pending intent means a previous commit for this id failed its cleanup in this process:
     // repair first (throws if impossible), so the intent written below always describes a
@@ -530,8 +532,21 @@ export async function createFolderBasedFileSystemContentStorage(
     if (await existsForInvariant(intentPathFor(id))) {
       await applyPendingIntent(intentPathFor(id))
     }
+    // The pre-rename phase awaits repair, existence checks and the journal write: an abort landing
+    // during any of them (with the source long consumed) must still cancel before the irreversible
+    // rename. Here no commit artifact exists yet, so a plain throw suffices; a completed repair
+    // above is idempotent state that needs no undoing.
+    signal?.throwIfAborted()
     const hadCounterpart = await existsForInvariant(counterpartPath)
     const intentPath = hadCounterpart ? await writeIntent(op, id, stagedPath) : undefined
+    if (intentPath && signal?.aborted) {
+      // Cancelled after the intent was journaled but before the rename: the commit never happened,
+      // so the journal must not survive (a later repair would apply it as a completed transition).
+      // Clearing it is must-succeed — if it cannot be cleared, the staged file is preserved as the
+      // proof the rename never landed, exactly like a failed rename.
+      await clearIntentOrThrowPreservingProof(intentPath, stagedPath, id, signal.reason)
+      signal.throwIfAborted()
+    }
     try {
       await rename(stagedPath, primaryPath)
     } catch (err) {
@@ -791,7 +806,7 @@ export async function createFolderBasedFileSystemContentStorage(
           // The raw and its .gzip are one versioned object: a gzip left from a previous version
           // would be preferred by retrieve() and serve stale bytes over the content just stored
           // (intent-journaled so even a crash mid-cleanup cannot leave the stale gzip preferred).
-          await commitRepresentation('raw', id, tempPath, filePath, filePath + '.gzip', rename)
+          await commitRepresentation('raw', id, tempPath, filePath, filePath + '.gzip', rename, signal)
         } finally {
           // Run the bookkeeping even when the commit throws (a failed counterpart cleanup reports
           // failure AFTER the rename landed): drop any stale decompress-cache tracking so eviction
@@ -1200,9 +1215,9 @@ export async function createFolderBasedFileSystemContentStorage(
           // Intent-journaled: a crash between the commit rename and the counterpart cleanup is
           // reconciled at next construction, never leaving mixed versions for reads to prefer.
           if (compressed) {
-            await commitRepresentation('gzip', id, stagedGzipPath, filePath + '.gzip', filePath, rename)
+            await commitRepresentation('gzip', id, stagedGzipPath, filePath + '.gzip', filePath, rename, signal)
           } else {
-            await commitRepresentation('raw', id, stagedRawPath, filePath, filePath + '.gzip', rename)
+            await commitRepresentation('raw', id, stagedRawPath, filePath, filePath + '.gzip', rename, signal)
           }
         } finally {
           // Run even when the commit throws post-rename (failed counterpart cleanup).

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -4,6 +4,7 @@ import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
+import { runStoreWithSignal } from './cancellation'
 import { compressContentFile } from './extras/compression'
 
 const pipe = promisify(pipeline)
@@ -721,7 +722,7 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  const storeStream = async (id: string, stream: Readable): Promise<void> => {
+  const doStoreStream = async (id: string, stream: Readable): Promise<void> => {
     const filePath = await getFilePath(id)
     const { rename } = components.fs
     // A custom fs adapter that predates the optional `rename` falls back to the original direct
@@ -1070,6 +1071,70 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
+  const doStoreStreamAndCompress = async (id: string, stream: Readable): Promise<void> => {
+    const filePath = await getFilePath(id)
+    const { rename } = components.fs
+    // Without rename (legacy custom fs adapter) everything is necessarily in place, so the whole
+    // sequence runs under the path lock: no concurrent store/delete can interleave between the
+    // raw write, the compression and the raw cleanup (which would otherwise be able to delete a
+    // newer writer's file). Not crash-atomic, like the rest of the no-rename mode.
+    if (!rename) {
+      await withPathLock(filePath, async () => {
+        await writeRawInPlaceLocked(id, filePath, stream)
+        if (await compressContentFile(filePath, logger)) {
+          // The in-place compression succeeded: the gzip exists at its canonical path and, under
+          // the lock, the raw is provably still the bytes that were compressed.
+          await noFailUnlink(filePath)
+        }
+      })
+      return
+    }
+    // Fully staged: both the raw bytes and their gzip are produced in the operation-owned staging
+    // area — the compression reads the PRIVATE staged raw, so no concurrent store/delete can
+    // supersede or fail it — and the id transitions in ONE locked commit to either the gzip-only
+    // or the raw-only representation of the new version. Until that commit the previous version
+    // stays fully intact; a process killed at any point leaves only sweepable staged files.
+    const stagedRawPath = newTempPath()
+    const stagedGzipPath = newTempPath()
+    // Set when a failed rename could not clear its intent: that exact staged path is the proof
+    // the commit never landed and must survive the staging cleanup below.
+    let preservedStagedPath: string | undefined
+    try {
+      await pipe(stream, components.fs.createWriteStream(stagedRawPath))
+      const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath)
+      await withPathLock(filePath, async () => {
+        try {
+          // Intent-journaled: a crash between the commit rename and the counterpart cleanup is
+          // reconciled at next construction, never leaving mixed versions for reads to prefer.
+          if (compressed) {
+            await commitRepresentation('gzip', id, stagedGzipPath, filePath + '.gzip', filePath, rename)
+          } else {
+            await commitRepresentation('raw', id, stagedRawPath, filePath, filePath + '.gzip', rename)
+          }
+        } finally {
+          // Run even when the commit throws post-rename (failed counterpart cleanup).
+          forgetCacheEntry(filePath)
+          invalidateInflightDecompression(filePath)
+        }
+      })
+    } catch (err) {
+      if (err instanceof UncommittedIntentSurvivedError) {
+        preservedStagedPath = err.stagedPath
+      }
+      throw err
+    } finally {
+      // Whatever was not renamed into place is staging residue (the raw after a gzip-only commit,
+      // both files after a failure) — except a preserved uncommitted-intent proof. The previous
+      // canonical version is untouched on any error.
+      if (stagedRawPath !== preservedStagedPath) {
+        await noFailUnlink(stagedRawPath)
+      }
+      if (stagedGzipPath !== preservedStagedPath) {
+        await noFailUnlink(stagedGzipPath)
+      }
+    }
+  }
+
   await reconcileIntents()
 
   return {
@@ -1108,72 +1173,12 @@ export async function createFolderBasedFileSystemContentStorage(
         await evictCacheEntry(filePath, entry)
       }
     },
-    storeStream,
+    storeStream: (id: string, stream: Readable, signal?: AbortSignal): Promise<void> =>
+      runStoreWithSignal(stream, signal, () => doStoreStream(id, stream)),
     retrieve,
     exist,
-    async storeStreamAndCompress(id: string, stream: Readable): Promise<void> {
-      const filePath = await getFilePath(id)
-      const { rename } = components.fs
-      // Without rename (legacy custom fs adapter) everything is necessarily in place, so the whole
-      // sequence runs under the path lock: no concurrent store/delete can interleave between the
-      // raw write, the compression and the raw cleanup (which would otherwise be able to delete a
-      // newer writer's file). Not crash-atomic, like the rest of the no-rename mode.
-      if (!rename) {
-        await withPathLock(filePath, async () => {
-          await writeRawInPlaceLocked(id, filePath, stream)
-          if (await compressContentFile(filePath, logger)) {
-            // The in-place compression succeeded: the gzip exists at its canonical path and, under
-            // the lock, the raw is provably still the bytes that were compressed.
-            await noFailUnlink(filePath)
-          }
-        })
-        return
-      }
-      // Fully staged: both the raw bytes and their gzip are produced in the operation-owned staging
-      // area — the compression reads the PRIVATE staged raw, so no concurrent store/delete can
-      // supersede or fail it — and the id transitions in ONE locked commit to either the gzip-only
-      // or the raw-only representation of the new version. Until that commit the previous version
-      // stays fully intact; a process killed at any point leaves only sweepable staged files.
-      const stagedRawPath = newTempPath()
-      const stagedGzipPath = newTempPath()
-      // Set when a failed rename could not clear its intent: that exact staged path is the proof
-      // the commit never landed and must survive the staging cleanup below.
-      let preservedStagedPath: string | undefined
-      try {
-        await pipe(stream, components.fs.createWriteStream(stagedRawPath))
-        const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath)
-        await withPathLock(filePath, async () => {
-          try {
-            // Intent-journaled: a crash between the commit rename and the counterpart cleanup is
-            // reconciled at next construction, never leaving mixed versions for reads to prefer.
-            if (compressed) {
-              await commitRepresentation('gzip', id, stagedGzipPath, filePath + '.gzip', filePath, rename)
-            } else {
-              await commitRepresentation('raw', id, stagedRawPath, filePath, filePath + '.gzip', rename)
-            }
-          } finally {
-            // Run even when the commit throws post-rename (failed counterpart cleanup).
-            forgetCacheEntry(filePath)
-            invalidateInflightDecompression(filePath)
-          }
-        })
-      } catch (err) {
-        if (err instanceof UncommittedIntentSurvivedError) {
-          preservedStagedPath = err.stagedPath
-        }
-        throw err
-      } finally {
-        // Whatever was not renamed into place is staging residue (the raw after a gzip-only commit,
-        // both files after a failure) — except a preserved uncommitted-intent proof. The previous
-        // canonical version is untouched on any error.
-        if (stagedRawPath !== preservedStagedPath) {
-          await noFailUnlink(stagedRawPath)
-        }
-        if (stagedGzipPath !== preservedStagedPath) {
-          await noFailUnlink(stagedGzipPath)
-        }
-      }
-    },
+    storeStreamAndCompress: (id: string, stream: Readable, signal?: AbortSignal): Promise<void> =>
+      runStoreWithSignal(stream, signal, () => doStoreStreamAndCompress(id, stream)),
     async delete(ids: string[]): Promise<void> {
       for (const id of ids) {
         const filePath = await getFilePath(id)

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -509,10 +509,15 @@ export async function createFolderBasedFileSystemContentStorage(
     try {
       await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename, signal)
     } catch (err) {
-      // Nothing inside the commit phase can be caused by abort teardown (the source is fully
-      // consumed before any commit begins, and the folder backend has no abort hook), so every
-      // failure here — pending-intent repair, journal write, rename, counterpart cleanup,
-      // quarantine — is a real storage error that cancellation translation must never mask.
+      // The commit phase's own cancellation checkpoints throw the caller's abort reason: pass those
+      // through untouched — they ARE cancellations, and marking would tag a caller-owned object
+      // with this module's internal symbol. Every other failure here — pending-intent repair,
+      // journal write, rename, counterpart cleanup, quarantine — cannot be caused by abort teardown
+      // (the source is fully consumed before any commit begins and this backend has no abort hook),
+      // so it is a real storage error that cancellation translation must never mask.
+      if (signal?.aborted && (err === signal.reason || isAbortError(err))) {
+        throw err
+      }
       throw markAsNonCancellationError(err)
     }
   }

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -4,7 +4,7 @@ import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
-import { runStoreWithSignal } from './cancellation'
+import { markAsNonCancellationError, runStoreWithSignal } from './cancellation'
 import { compressContentFile } from './extras/compression'
 
 const pipe = promisify(pipeline)
@@ -505,6 +505,25 @@ export async function createFolderBasedFileSystemContentStorage(
     counterpartPath: string,
     rename: (from: string, to: string) => Promise<void>
   ): Promise<void> {
+    try {
+      await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename)
+    } catch (err) {
+      // Nothing inside the commit phase can be caused by abort teardown (the source is fully
+      // consumed before any commit begins, and the folder backend has no abort hook), so every
+      // failure here — pending-intent repair, journal write, rename, counterpart cleanup,
+      // quarantine — is a real storage error that cancellation translation must never mask.
+      throw markAsNonCancellationError(err)
+    }
+  }
+
+  async function doCommitRepresentation(
+    op: 'raw' | 'gzip',
+    id: string,
+    stagedPath: string,
+    primaryPath: string,
+    counterpartPath: string,
+    rename: (from: string, to: string) => Promise<void>
+  ): Promise<void> {
     // A pending intent means a previous commit for this id failed its cleanup in this process:
     // repair first (throws if impossible), so the intent written below always describes a
     // transition from a consistent state and never overwrites an unapplied repair instruction.
@@ -582,9 +601,12 @@ export async function createFolderBasedFileSystemContentStorage(
       await pipe(stream, components.fs.createWriteStream(filePath))
       await noFailUnlink(filePath + '.gzip')
       if (await existsForInvariant(filePath + '.gzip')) {
-        throw new Error(
-          `Failed to remove the previous gzip representation of ${id}; the in-place store was rolled back ` +
-            `and reads keep serving the previous version.`
+        // A post-write invariant failure, never abort-caused: keep it visible past cancellation.
+        throw markAsNonCancellationError(
+          new Error(
+            `Failed to remove the previous gzip representation of ${id}; the in-place store was rolled back ` +
+              `and reads keep serving the previous version.`
+          )
         )
       }
       forgetCacheEntry(filePath)
@@ -1104,11 +1126,23 @@ export async function createFolderBasedFileSystemContentStorage(
         await writeRawInPlaceLocked(id, filePath, stream, signal)
         // An abort observed here arrives after the in-place raw was committed (the previous version
         // is already gone): the store is complete and allowed to succeed, but the optional
-        // compression is skipped rather than doing further expensive work for a cancelled request.
-        if (!signal?.aborted && (await compressContentFile(filePath, logger))) {
-          // The in-place compression succeeded: the gzip exists at its canonical path and, under
-          // the lock, the raw is provably still the bytes that were compressed.
-          await noFailUnlink(filePath)
+        // compression is skipped — or torn down mid-flight via the signal — rather than doing
+        // further expensive work for a cancelled request.
+        if (!signal?.aborted) {
+          let compressed = false
+          try {
+            compressed = await compressContentFile(filePath, logger, undefined, signal)
+          } catch (err) {
+            // An abort-caused pipeline teardown is not a failure of this (already completed) store:
+            // the partial canonical gzip was removed by the compression's own cleanup and the raw
+            // stays primary. Genuine compression failures still propagate as before.
+            if (!signal?.aborted) throw err
+          }
+          if (compressed) {
+            // The in-place compression succeeded: the gzip exists at its canonical path and, under
+            // the lock, the raw is provably still the bytes that were compressed.
+            await noFailUnlink(filePath)
+          }
         }
       })
       return
@@ -1130,7 +1164,10 @@ export async function createFolderBasedFileSystemContentStorage(
       // object. Nothing has touched the canonical paths yet — the finally below removes the staged
       // residue and the previous version stays fully intact.
       signal?.throwIfAborted()
-      const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath)
+      // The signal also aborts the compression pipeline itself mid-flight (its partial staged
+      // output is removed before the rejection propagates), so a cancelled request stops paying
+      // CPU/disk immediately instead of only at the next checkpoint.
+      const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath, signal)
       signal?.throwIfAborted()
       await withPathLock(filePath, async () => {
         // Re-check INSIDE the lock: an abort landing while this store was queued on the path lock

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -564,9 +564,18 @@ export async function createFolderBasedFileSystemContentStorage(
   // while the preferred gzip counterpart survives. There is no journal in this mode, so a surviving
   // gzip rolls the in-place store back through the catch — the previous gzip version stays cleanly
   // intact (the raw overwritten by the pipe can only have been that gzip's own re-derivable cache).
-  async function writeRawInPlaceLocked(id: string, filePath: string, stream: Readable): Promise<void> {
+  async function writeRawInPlaceLocked(
+    id: string,
+    filePath: string,
+    stream: Readable,
+    signal?: AbortSignal
+  ): Promise<void> {
     try {
       await pipe(stream, components.fs.createWriteStream(filePath))
+      // An abort observed once the source is consumed must still cancel the store: without this
+      // checkpoint the in-place write would be committed for a cancelled request. Throwing here
+      // rolls back through the catch below, so nothing is stored.
+      signal?.throwIfAborted()
       await noFailUnlink(filePath + '.gzip')
       if (await existsForInvariant(filePath + '.gzip')) {
         throw new Error(
@@ -722,14 +731,14 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  const doStoreStream = async (id: string, stream: Readable): Promise<void> => {
+  const doStoreStream = async (id: string, stream: Readable, signal?: AbortSignal): Promise<void> => {
     const filePath = await getFilePath(id)
     const { rename } = components.fs
     // A custom fs adapter that predates the optional `rename` falls back to the original direct
     // write. It isn't crash-atomic, but keeps the public IFileSystemComponent backward-compatible;
     // the bundled createFsComponent provides rename and so takes the atomic path below.
     if (!rename) {
-      await withPathLock(filePath, () => writeRawInPlaceLocked(id, filePath, stream))
+      await withPathLock(filePath, () => writeRawInPlaceLocked(id, filePath, stream, signal))
       return
     }
     // Stage the write in the reserved temp dir under a random name, then atomically rename it into
@@ -743,6 +752,9 @@ export async function createFolderBasedFileSystemContentStorage(
     const tempPath = newTempPath()
     try {
       await pipe(stream, components.fs.createWriteStream(tempPath))
+      // An abort observed once the source is consumed must still cancel the store before the
+      // commit; the catch below removes the staged file and the canonical path stays untouched.
+      signal?.throwIfAborted()
       await withPathLock(filePath, async () => {
         try {
           // The raw and its .gzip are one versioned object: a gzip left from a previous version
@@ -1071,7 +1083,7 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  const doStoreStreamAndCompress = async (id: string, stream: Readable): Promise<void> => {
+  const doStoreStreamAndCompress = async (id: string, stream: Readable, signal?: AbortSignal): Promise<void> => {
     const filePath = await getFilePath(id)
     const { rename } = components.fs
     // Without rename (legacy custom fs adapter) everything is necessarily in place, so the whole
@@ -1080,8 +1092,11 @@ export async function createFolderBasedFileSystemContentStorage(
     // newer writer's file). Not crash-atomic, like the rest of the no-rename mode.
     if (!rename) {
       await withPathLock(filePath, async () => {
-        await writeRawInPlaceLocked(id, filePath, stream)
-        if (await compressContentFile(filePath, logger)) {
+        await writeRawInPlaceLocked(id, filePath, stream, signal)
+        // An abort observed here arrives after the in-place raw was committed (the previous version
+        // is already gone): the store is complete and allowed to succeed, but the optional
+        // compression is skipped rather than doing further expensive work for a cancelled request.
+        if (!signal?.aborted && (await compressContentFile(filePath, logger))) {
           // The in-place compression succeeded: the gzip exists at its canonical path and, under
           // the lock, the raw is provably still the bytes that were compressed.
           await noFailUnlink(filePath)
@@ -1101,7 +1116,13 @@ export async function createFolderBasedFileSystemContentStorage(
     let preservedStagedPath: string | undefined
     try {
       await pipe(stream, components.fs.createWriteStream(stagedRawPath))
+      // An abort observed once the source is consumed must still cancel the store: without these
+      // checkpoints a cancelled request would keep paying for the compression and even commit the
+      // object. Nothing has touched the canonical paths yet — the finally below removes the staged
+      // residue and the previous version stays fully intact.
+      signal?.throwIfAborted()
       const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath)
+      signal?.throwIfAborted()
       await withPathLock(filePath, async () => {
         try {
           // Intent-journaled: a crash between the commit rename and the counterpart cleanup is
@@ -1174,11 +1195,11 @@ export async function createFolderBasedFileSystemContentStorage(
       }
     },
     storeStream: (id: string, stream: Readable, signal?: AbortSignal): Promise<void> =>
-      runStoreWithSignal(stream, signal, () => doStoreStream(id, stream)),
+      runStoreWithSignal(stream, signal, () => doStoreStream(id, stream, signal)),
     retrieve,
     exist,
     storeStreamAndCompress: (id: string, stream: Readable, signal?: AbortSignal): Promise<void> =>
-      runStoreWithSignal(stream, signal, () => doStoreStreamAndCompress(id, stream)),
+      runStoreWithSignal(stream, signal, () => doStoreStreamAndCompress(id, stream, signal)),
     async delete(ids: string[]): Promise<void> {
       for (const id of ids) {
         const filePath = await getFilePath(id)

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -509,13 +509,14 @@ export async function createFolderBasedFileSystemContentStorage(
     try {
       await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename, signal)
     } catch (err) {
-      // The commit phase's own cancellation checkpoints throw the caller's abort reason: pass those
-      // through untouched — they ARE cancellations, and marking would tag a caller-owned object
-      // with this module's internal symbol. Every other failure here — pending-intent repair,
-      // journal write, rename, counterpart cleanup, quarantine — cannot be caused by abort teardown
-      // (the source is fully consumed before any commit begins and this backend has no abort hook),
-      // so it is a real storage error that cancellation translation must never mask.
-      if (signal?.aborted && (err === signal.reason || isAbortError(err))) {
+      // The commit phase's own cancellation checkpoints throw the caller's abort reason and nothing
+      // else, so identity is the whole test: pass that through untouched (it IS a cancellation, and
+      // marking would tag a caller-owned object with this module's internal symbol). Every other
+      // failure here — pending-intent repair, journal write, rename, counterpart cleanup, quarantine
+      // — cannot be caused by abort teardown (the source is fully consumed before any commit begins
+      // and this backend has no abort hook), so it is a real storage error that cancellation
+      // translation must never mask, whatever shape it happens to have.
+      if (signal?.aborted && err === signal.reason) {
         throw err
       }
       throw markAsNonCancellationError(err)

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -1212,7 +1212,19 @@ export async function createFolderBasedFileSystemContentStorage(
       // The signal also aborts the compression pipeline itself mid-flight (its partial staged
       // output is removed before the rejection propagates), so a cancelled request stops paying
       // CPU/disk immediately instead of only at the next checkpoint.
-      const compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath, signal)
+      let compressed: boolean
+      try {
+        compressed = await compressContentFile(stagedRawPath, logger, stagedGzipPath, signal)
+      } catch (err) {
+        // This call site is the one place that hands a signal to an abortable pipeline, so it is
+        // where an abort-shaped rejection is provably our own teardown rather than a coincidence:
+        // convert it to the caller's reason here, which lets the generic translation stay strict
+        // about abort shapes it cannot attribute. Any other failure surfaces as itself.
+        if (signal?.aborted && isAbortError(err)) {
+          signal.throwIfAborted()
+        }
+        throw err
+      }
       signal?.throwIfAborted()
       await withPathLock(filePath, async () => {
         // Re-check INSIDE the lock: an abort landing while this store was queued on the path lock

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -4,7 +4,7 @@ import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
-import { markAsNonCancellationError, runStoreWithSignal } from './cancellation'
+import { isAbortError, markAsNonCancellationError, runStoreWithSignal } from './cancellation'
 import { compressContentFile } from './extras/compression'
 
 const pipe = promisify(pipeline)
@@ -1133,10 +1133,31 @@ export async function createFolderBasedFileSystemContentStorage(
           try {
             compressed = await compressContentFile(filePath, logger, undefined, signal)
           } catch (err) {
-            // An abort-caused pipeline teardown is not a failure of this (already completed) store:
-            // the partial canonical gzip was removed by the compression's own cleanup and the raw
-            // stays primary. Genuine compression failures still propagate as before.
-            if (!signal?.aborted) throw err
+            // The compression failed (or was torn down): its own cleanup of the partial canonical
+            // output is best-effort, so VERIFY none survived — in this mode the compression writes
+            // to the canonical `.gzip` directly, reads prefer `.gzip`, and a surviving partial
+            // would be served as corrupt content over the just-committed raw. Failures here are
+            // post-commit storage errors, never abort-caused, so they must stay visible.
+            try {
+              await noFailUnlink(filePath + '.gzip')
+              if (await existsForInvariant(filePath + '.gzip')) {
+                throw new Error(
+                  `Compression of ${id} failed and its partial gzip output could not be removed; ` +
+                    `reads would prefer the corrupt gzip over the committed raw.`
+                )
+              }
+            } catch (invariantErr) {
+              throw markAsNonCancellationError(invariantErr)
+            }
+            if (signal?.aborted && isAbortError(err)) {
+              // Provably abort-caused pipeline teardown of an optional post-commit compression:
+              // not a failure of this (already completed) store — the raw stays primary.
+            } else {
+              // A real compression/storage failure that merely RACED the abort (ENOSPC, EACCES,
+              // zlib errors, …): resolving would hide it as a successful store, and unmarked it
+              // would be translated to the cancellation reason. Surface it as-is.
+              throw markAsNonCancellationError(err)
+            }
           }
           if (compressed) {
             // The in-place compression succeeded: the gzip exists at its canonical path and, under

--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -545,8 +545,12 @@ export async function createFolderBasedFileSystemContentStorage(
       // Clearing it is must-succeed — if it cannot be cleared, the staged file is preserved as the
       // proof the rename never landed, exactly like a failed rename.
       await clearIntentOrThrowPreservingProof(intentPath, stagedPath, id, signal.reason)
-      signal.throwIfAborted()
     }
+    // Unconditional last checkpoint before the irreversible rename: without it, an abort landing
+    // during the awaited counterpart check on a fresh id (no counterpart → no intent → the block
+    // above skipped) would proceed to commit. No journal exists past this line unless it was just
+    // cleared, so a plain throw is safe.
+    signal?.throwIfAborted()
     try {
       await rename(stagedPath, primaryPath)
     } catch (err) {

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'stream'
 import { clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem, streamToBuffer } from './content-item'
+import { runStoreWithSignal } from './cancellation'
 
 /**
  * @public
@@ -14,14 +15,14 @@ export function createInMemoryStorage(): IContentStorageComponent {
   }
 
   return {
-    async storeStreamAndCompress(fileId: string, content: Readable): Promise<void> {
-      storage.set(fileId, await streamToBuffer(content))
+    async storeStreamAndCompress(fileId: string, content: Readable, signal?: AbortSignal): Promise<void> {
+      storage.set(fileId, await runStoreWithSignal(content, signal, () => streamToBuffer(content)))
     },
     async exist(fileId: string): Promise<boolean> {
       return storage.has(fileId)
     },
-    async storeStream(fileId: string, content: Readable): Promise<void> {
-      storage.set(fileId, await streamToBuffer(content))
+    async storeStream(fileId: string, content: Readable, signal?: AbortSignal): Promise<void> {
+      storage.set(fileId, await runStoreWithSignal(content, signal, () => streamToBuffer(content)))
     },
     async delete(ids: string[]): Promise<void> {
       ids.forEach((id) => storage.delete(id))

--- a/src/in-memory-storage-component.ts
+++ b/src/in-memory-storage-component.ts
@@ -14,16 +14,23 @@ export function createInMemoryStorage(): IContentStorageComponent {
     return buffer ? { encoding: null, size: buffer!.length, contentSize: buffer!.length } : undefined
   }
 
+  // Shared by both store methods (this backend does not compress). The checkpoint before the commit
+  // matters for the same reason it does in the other backends: once the source is consumed,
+  // destroying it cancels nothing, so without it an abort observed during the read would still
+  // commit content for a cancelled request.
+  const storeBuffered = (fileId: string, content: Readable, signal?: AbortSignal): Promise<void> =>
+    runStoreWithSignal(content, signal, async () => {
+      const buffer = await streamToBuffer(content)
+      signal?.throwIfAborted()
+      storage.set(fileId, buffer)
+    })
+
   return {
-    async storeStreamAndCompress(fileId: string, content: Readable, signal?: AbortSignal): Promise<void> {
-      storage.set(fileId, await runStoreWithSignal(content, signal, () => streamToBuffer(content)))
-    },
+    storeStreamAndCompress: storeBuffered,
     async exist(fileId: string): Promise<boolean> {
       return storage.has(fileId)
     },
-    async storeStream(fileId: string, content: Readable, signal?: AbortSignal): Promise<void> {
-      storage.set(fileId, await runStoreWithSignal(content, signal, () => streamToBuffer(content)))
-    },
+    storeStream: storeBuffered,
     async delete(ids: string[]): Promise<void> {
       ids.forEach((id) => storage.delete(id))
     },

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -2,6 +2,7 @@ import { S3 } from 'aws-sdk'
 import { Readable } from 'stream'
 import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageComponent, validateRange } from './types'
 import { SimpleContentItem } from './content-item'
+import { runStoreWithSignal } from './cancellation'
 import { ListObjectsV2Output } from 'aws-sdk/clients/s3'
 // Workaround: TS "commonjs" transforms import() to require().
 // This indirection preserves the native import() needed for ESM-only packages.
@@ -116,30 +117,42 @@ export async function createS3BasedFileSystemContentStorage(
     }
   }
 
-  async function storeStream(id: string, stream: Readable): Promise<void> {
-    // Inspect only the head for MIME detection, then stream the body straight to S3 so large
-    // files are never buffered in memory. The AWS SDK's managed upload performs a multipart
-    // upload, buffering only part-sized chunks rather than the whole file.
-    const { head, body } = await peekHead(stream, MIME_DETECTION_BYTES)
-    const mimeType = await detectMimeTypeFromBuffer(head)
+  async function storeStream(id: string, stream: Readable, signal?: AbortSignal): Promise<void> {
+    // Destroying the source on abort is not enough to cancel the upload: once the SDK has
+    // buffered the bytes (always, for files below the part size) the request no longer depends
+    // on the source, so the managed upload itself must be aborted to tear down its transport.
+    let upload: S3.ManagedUpload | undefined
+    await runStoreWithSignal(
+      stream,
+      signal,
+      async () => {
+        // Inspect only the head for MIME detection, then stream the body straight to S3 so large
+        // files are never buffered in memory. The AWS SDK's managed upload performs a multipart
+        // upload, buffering only part-sized chunks rather than the whole file.
+        const { head, body } = await peekHead(stream, MIME_DETECTION_BYTES)
+        const mimeType = await detectMimeTypeFromBuffer(head)
+        signal?.throwIfAborted()
 
-    try {
-      await s3
-        .upload({
+        upload = s3.upload({
           Bucket,
           Key: getKey(id),
           Body: body,
           ContentType: mimeType
         })
-        .promise()
-    } catch (error) {
-      // Release the source stream if the upload stopped consuming the body (e.g. it failed before
-      // reading anything, so peekHead's generator never started and can't self-clean). Destroying
-      // the source releases its underlying resources (e.g. file descriptors). No-op if already
-      // ended/destroyed.
-      stream.destroy()
-      throw error
-    }
+        try {
+          await upload.promise()
+        } catch (error) {
+          // Release the source stream if the upload stopped consuming the body (e.g. it failed
+          // before reading anything, so peekHead's generator never started and can't self-clean).
+          // Destroying the source releases its underlying resources (e.g. file descriptors).
+          // No-op if already ended/destroyed.
+          stream.destroy()
+          throw error
+        }
+      },
+      // Optional call: S3-compatible test doubles may not implement ManagedUpload.abort().
+      () => upload?.abort?.()
+    )
   }
 
   async function retrieve(id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> {
@@ -187,9 +200,9 @@ export async function createS3BasedFileSystemContentStorage(
     return undefined
   }
 
-  async function storeStreamAndCompress(id: string, stream: Readable): Promise<void> {
+  async function storeStreamAndCompress(id: string, stream: Readable, signal?: AbortSignal): Promise<void> {
     // In AWS S3 we don't compress, we directly store the stream
-    await storeStream(id, stream)
+    await storeStream(id, stream, signal)
   }
 
   async function deleteFn(ids: string[]): Promise<void> {

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -139,6 +139,15 @@ export async function createS3BasedFileSystemContentStorage(
           Body: body,
           ContentType: mimeType
         })
+        // The abort listener can only tear the upload down once `upload` is assigned: an abort
+        // landing before this point found `upload` undefined and did nothing, and — with a small
+        // source already fully buffered into the head — the upload no longer needs the source, so
+        // it would complete and commit content for an already-cancelled store. Re-check here, where
+        // the ManagedUpload provably exists, and tear it down ourselves.
+        if (signal?.aborted) {
+          upload.abort?.()
+          signal.throwIfAborted()
+        }
         try {
           await upload.promise()
         } catch (error) {

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -145,7 +145,13 @@ export async function createS3BasedFileSystemContentStorage(
         // it would complete and commit content for an already-cancelled store. Re-check here, where
         // the ManagedUpload provably exists, and tear it down ourselves.
         if (signal?.aborted) {
-          upload.abort?.()
+          // Guarded like the listener's hook: a custom S3-compatible abort() that throws must not
+          // replace the caller's cancellation reason thrown below.
+          try {
+            upload.abort?.()
+          } catch {
+            // best-effort teardown
+          }
           signal.throwIfAborted()
         }
         try {

--- a/src/s3-based-storage-component.ts
+++ b/src/s3-based-storage-component.ts
@@ -154,13 +154,25 @@ export async function createS3BasedFileSystemContentStorage(
           // Release the source stream if the upload stopped consuming the body (e.g. it failed
           // before reading anything, so peekHead's generator never started and can't self-clean).
           // Destroying the source releases its underlying resources (e.g. file descriptors).
-          // No-op if already ended/destroyed.
-          stream.destroy()
+          // No-op if already ended/destroyed. Guarded so a custom stream whose destroy() throws
+          // cannot replace the upload error the caller needs to see.
+          try {
+            stream.destroy()
+          } catch {
+            // best-effort cleanup; the upload error below is what matters
+          }
           throw error
         }
       },
-      // Optional call: S3-compatible test doubles may not implement ManagedUpload.abort().
-      () => upload?.abort?.()
+      // Reports whether the managed upload was actually torn down, so a `RequestAbortedError` is
+      // credited to this cancellation only when our abort caused it — the SDK can report an aborted
+      // request for reasons of its own (e.g. a socket teardown) that merely race the cancellation.
+      // The call is optional: S3-compatible test doubles may not implement ManagedUpload.abort().
+      () => {
+        if (!upload?.abort) return false
+        upload.abort()
+        return true
+      }
     )
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,14 @@ export type IContentStorageComponent = IBaseComponent & {
    * @param signal Optional cancellation signal. When it aborts, the store stops consuming the
    * stream, tears down any in-flight transport (e.g. the S3 upload), and rejects with the
    * signal's reason. A store that completes before observing the abort is allowed to succeed;
-   * either way no partial content is ever observable under the id.
+   * either way no partial content is ever observable under the id, and in atomic mode the
+   * previous version of the id stays intact on cancellation.
+   *
+   * Legacy no-rename folder mode (a filesystem component without `rename`) writes in place, so
+   * cancellation there is only honored before the destructive write begins: an abort observed
+   * after the write completes the store, and an abort mid-write follows the mode's usual
+   * non-atomic semantics — the partial overwrite is removed, but the previous version of an
+   * overwritten id cannot be preserved.
    */
   storeStream(fileId: string, content: Readable, signal?: AbortSignal): Promise<void>
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,8 +14,21 @@ export type AppComponents = {
  * @public
  */
 export type IContentStorageComponent = IBaseComponent & {
-  storeStream(fileId: string, content: Readable): Promise<void>
-  storeStreamAndCompress(fileId: string, content: Readable): Promise<void>
+  /**
+   * Stores the stream under the given id.
+   *
+   * @param signal Optional cancellation signal. When it aborts, the store stops consuming the
+   * stream, tears down any in-flight transport (e.g. the S3 upload), and rejects with the
+   * signal's reason. A store that completes before observing the abort is allowed to succeed;
+   * either way no partial content is ever observable under the id.
+   */
+  storeStream(fileId: string, content: Readable, signal?: AbortSignal): Promise<void>
+  /**
+   * Stores the stream under the given id, compressed when the backend supports it.
+   *
+   * @param signal Optional cancellation signal with the same semantics as {@link storeStream}.
+   */
+  storeStreamAndCompress(fileId: string, content: Readable, signal?: AbortSignal): Promise<void>
   delete(fileIds: string[]): Promise<void>
   retrieve(fileId: string, range?: { start: number; end: number }): Promise<ContentItem | undefined>
   fileInfo(fileId: string): Promise<FileInfo | undefined>

--- a/test/behavior.spec.ts
+++ b/test/behavior.spec.ts
@@ -83,6 +83,24 @@ function createCommonSuite(components: { storage?: IContentStorageComponent }) {
     expect(await components.storage!.exist('signal/mid-aborted')).toBe(false)
   })
 
+  it(`When the signal aborts after the source was fully consumed, then the store rejects with the reason and stores nothing`, async () => {
+    // Every backend must honor an abort observed once the source is consumed: destroying the source
+    // no longer cancels anything, so without a checkpoint before the commit a cancelled request
+    // would still store content. The 'end' listener is registered before the store consumes the
+    // stream, so it aborts in the same event as the read completing.
+    const reason = new Error('cancelled after the source ended')
+    const controller = new AbortController()
+    const source = new Readable({ read() {} })
+    source.push(Buffer.from('fully-consumed-content'))
+    source.push(null)
+    source.on('end', () => controller.abort(reason))
+
+    await expect(components.storage!.storeStream('signal/post-consumption', source, controller.signal)).rejects.toBe(
+      reason
+    )
+    expect(await components.storage!.exist('signal/post-consumption')).toBe(false)
+  })
+
   it(`When the signal aborts while a compressed store is still streaming, then it rejects with the reason and stores nothing`, async () => {
     const reason = new Error('cancelled mid-compress')
     const controller = new AbortController()

--- a/test/behavior.spec.ts
+++ b/test/behavior.spec.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from 'fs'
 import os from 'os'
 import path from 'path'
+import { Readable } from 'stream'
 import {
   createFolderBasedFileSystemContentStorage,
   createFsComponent,
@@ -47,6 +48,53 @@ function createCommonSuite(components: { storage?: IContentStorageComponent }) {
       'f/b/c/3': true,
       'f/b/c/4': true
     })
+  })
+
+  it(`When a signal is provided but never aborts, then the store completes normally`, async () => {
+    const controller = new AbortController()
+
+    await components.storage!.storeStream('signal/completed', bufferToStream(Buffer.from('123456')), controller.signal)
+
+    expect(await components.storage!.exist('signal/completed')).toBe(true)
+  })
+
+  it(`When the signal is already aborted, then the store rejects with the reason and stores nothing`, async () => {
+    const reason = new Error('cancelled before start')
+    const controller = new AbortController()
+    controller.abort(reason)
+
+    await expect(
+      components.storage!.storeStream('signal/pre-aborted', bufferToStream(Buffer.from('123456')), controller.signal)
+    ).rejects.toBe(reason)
+    expect(await components.storage!.exist('signal/pre-aborted')).toBe(false)
+  })
+
+  it(`When the signal aborts while the source is still streaming, then the store rejects with the reason and stores nothing`, async () => {
+    const reason = new Error('cancelled mid-stream')
+    const controller = new AbortController()
+    const source = new Readable({ read() {} })
+    source.push(Buffer.from('first-chunk'))
+
+    const pending = components.storage!.storeStream('signal/mid-aborted', source, controller.signal)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    controller.abort(reason)
+
+    await expect(pending).rejects.toBe(reason)
+    expect(await components.storage!.exist('signal/mid-aborted')).toBe(false)
+  })
+
+  it(`When the signal aborts while a compressed store is still streaming, then it rejects with the reason and stores nothing`, async () => {
+    const reason = new Error('cancelled mid-compress')
+    const controller = new AbortController()
+    const source = new Readable({ read() {} })
+    source.push(Buffer.from('first-chunk'))
+
+    const pending = components.storage!.storeStreamAndCompress('signal/mid-aborted-gzip', source, controller.signal)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    controller.abort(reason)
+
+    await expect(pending).rejects.toBe(reason)
+    expect(await components.storage!.exist('signal/mid-aborted-gzip')).toBe(false)
   })
 }
 

--- a/test/buffer-utils.spec.ts
+++ b/test/buffer-utils.spec.ts
@@ -1,4 +1,5 @@
 import { createReadStream, readFileSync } from 'fs'
+import { Readable } from 'stream'
 import { bufferToStream, streamToBuffer } from '../src/content-item'
 
 describe('Buffer utils', () => {
@@ -31,5 +32,17 @@ describe('Buffer utils', () => {
     const b = Buffer.from(new Uint8Array(1000000).fill(0))
     const s = bufferToStream(b)
     expect(await streamToBuffer(s)).toEqual(b)
+  })
+})
+
+describe('streamToBuffer premature close', () => {
+  it('rejects when the stream is destroyed without an error before ending', async () => {
+    const stream = new Readable({ read() {} })
+    stream.push(Buffer.from('123'))
+    const pending = streamToBuffer(stream)
+
+    stream.destroy()
+
+    await expect(pending).rejects.toThrow('Stream closed before it ended.')
   })
 })

--- a/test/cancellation.spec.ts
+++ b/test/cancellation.spec.ts
@@ -161,6 +161,43 @@ describe('runStoreWithSignal', () => {
     })
   })
 
+  describe('when the source had already ended but was not yet destroyed', () => {
+    let prematureClose: Error
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // An ended-but-undestroyed source (reachable with autoDestroy: false, or in the tick before an
+      // auto-destroy lands) cannot be made to close prematurely by our teardown — the consumer
+      // already got its 'end'. So a premature-close rejection here belongs to something else and
+      // must surface as itself, even though the teardown did call destroy() as cleanup.
+      prematureClose = Object.assign(new Error('Premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' })
+      const source = new Readable({ read() {}, autoDestroy: false })
+      source.push(Buffer.from('fully-read'))
+      source.push(null)
+      source.resume()
+      await new Promise<void>((resolve) => source.once('end', () => resolve()))
+      expect(source.readableEnded).toBe(true)
+      expect(source.destroyed).toBe(false)
+
+      const controller = new AbortController()
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      const pending = runStoreWithSignal(source, controller.signal, () => operation)
+      controller.abort(new Error('cancelled'))
+      rejectOperation(prematureClose)
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should surface the premature close instead of the cancellation reason', () => {
+      expect(outcome).toBe(prematureClose)
+    })
+  })
+
   describe('when an operation raises an abort-shaped error of its own', () => {
     let foreignAbortError: Error
     let outcome: 'resolved' | unknown

--- a/test/cancellation.spec.ts
+++ b/test/cancellation.spec.ts
@@ -161,6 +161,38 @@ describe('runStoreWithSignal', () => {
     })
   })
 
+  describe('when an operation raises an abort-shaped error of its own', () => {
+    let foreignAbortError: Error
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // A custom stream or transport can raise an AbortError for reasons of its own that merely
+      // coincide with the caller's cancellation. Nothing here handed it this signal, so the shape
+      // alone must not earn translation — the caller needs to see the real failure.
+      foreignAbortError = Object.assign(new Error('The custom transport aborted internally'), {
+        name: 'AbortError',
+        code: 'ABORT_ERR'
+      })
+      const controller = new AbortController()
+      const source = new Readable({ read() {} })
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      const pending = runStoreWithSignal(source, controller.signal, () => operation)
+      controller.abort(new Error('cancelled'))
+      rejectOperation(foreignAbortError)
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should surface the foreign abort error instead of the cancellation reason', () => {
+      expect(outcome).toBe(foreignAbortError)
+    })
+  })
+
   describe('when the abort reason is an explicit null', () => {
     let outcome: 'resolved' | unknown
 

--- a/test/cancellation.spec.ts
+++ b/test/cancellation.spec.ts
@@ -1,0 +1,89 @@
+import { Readable } from 'stream'
+import { runStoreWithSignal } from '../src/cancellation'
+
+describe('runStoreWithSignal', () => {
+  describe('when the abort hook throws', () => {
+    let reason: Error
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // The hook runs inside the signal's event dispatch: a teardown failure must neither escape
+      // as an uncaught exception nor replace the caller's cancellation reason.
+      reason = new Error('cancelled')
+      const controller = new AbortController()
+      const source = new Readable({ read() {} })
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      const failingHook = (): void => {
+        rejectOperation(new Error('transport torn down'))
+        throw new Error('teardown exploded')
+      }
+      const pending = runStoreWithSignal(source, controller.signal, () => operation, failingHook)
+      controller.abort(reason)
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should reject with the abort reason despite the hook failure', () => {
+      expect(outcome).toBe(reason)
+    })
+  })
+
+  describe('when destroying the source throws', () => {
+    let reason: Error
+    let hookCalled: jest.Mock
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // A failing stream teardown must not prevent the backend hook from running.
+      reason = new Error('cancelled')
+      const controller = new AbortController()
+      const source = new Readable({ read() {} })
+      source.destroy = (() => {
+        throw new Error('destroy exploded')
+      }) as typeof source.destroy
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      hookCalled = jest.fn(() => rejectOperation(new Error('transport torn down')))
+      const pending = runStoreWithSignal(source, controller.signal, () => operation, hookCalled)
+      controller.abort(reason)
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should still run the abort hook', () => {
+      expect(hookCalled).toHaveBeenCalled()
+    })
+
+    it('should reject with the abort reason', () => {
+      expect(outcome).toBe(reason)
+    })
+  })
+
+  describe('when the abort reason is an explicit null', () => {
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // The docs promise the caller observes their own cancellation cause — including null.
+      const controller = new AbortController()
+      controller.abort(null)
+      const source = new Readable({ read() {} })
+      outcome = await runStoreWithSignal(source, controller.signal, () => new Promise<never>(() => undefined)).then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should reject with null instead of a synthesized error', () => {
+      expect(outcome).toBe(null)
+    })
+  })
+})

--- a/test/cancellation.spec.ts
+++ b/test/cancellation.spec.ts
@@ -126,6 +126,36 @@ describe('runStoreWithSignal', () => {
     })
   })
 
+  describe('when the source closed prematurely on its own before the abort', () => {
+    let upstreamFault: Error
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // The source died for a real upstream fault BEFORE the abort fired: the teardown destroyed
+      // nothing, so the premature-close failure belongs to that fault and must surface as itself —
+      // the public ERR_STREAM_PREMATURE_CLOSE shape alone is not proof of our teardown.
+      upstreamFault = Object.assign(new Error('Premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' })
+      const controller = new AbortController()
+      const source = new Readable({ read() {} })
+      source.destroy()
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      const pending = runStoreWithSignal(source, controller.signal, () => operation)
+      controller.abort(new Error('cancelled'))
+      rejectOperation(upstreamFault)
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should surface the upstream fault instead of the cancellation reason', () => {
+      expect(outcome).toBe(upstreamFault)
+    })
+  })
+
   describe('when the abort reason is an explicit null', () => {
     let outcome: 'resolved' | unknown
 

--- a/test/cancellation.spec.ts
+++ b/test/cancellation.spec.ts
@@ -17,8 +17,10 @@ describe('runStoreWithSignal', () => {
         rejectOperation = reject
       })
       const failingHook = (): void => {
-        // Teardown-shaped, as a real aborted transport rejects (e.g. S3 RequestAbortedError).
-        rejectOperation(Object.assign(new Error('transport torn down'), { code: 'RequestAbortedError' }))
+        // A hook that throws never reports tearing transport down, so the rejection it causes is
+        // shaped like what the destroyed source produces (a premature close) — provenance for that
+        // comes from the listener's own destroy, not from the hook.
+        rejectOperation(Object.assign(new Error('Premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))
         throw new Error('teardown exploded')
       }
       const pending = runStoreWithSignal(source, controller.signal, () => operation, failingHook)
@@ -51,9 +53,12 @@ describe('runStoreWithSignal', () => {
       const operation = new Promise<never>((_, reject) => {
         rejectOperation = reject
       })
-      hookCalled = jest.fn(() =>
+      // A real hook reports that it tore the transport down, which is what credits the resulting
+      // transport-shaped rejection to this cancellation.
+      hookCalled = jest.fn(() => {
         rejectOperation(Object.assign(new Error('transport torn down'), { code: 'RequestAbortedError' }))
-      )
+        return true
+      })
       const pending = runStoreWithSignal(source, controller.signal, () => operation, hookCalled)
       controller.abort(reason)
       outcome = await pending.then(

--- a/test/cancellation.spec.ts
+++ b/test/cancellation.spec.ts
@@ -17,7 +17,8 @@ describe('runStoreWithSignal', () => {
         rejectOperation = reject
       })
       const failingHook = (): void => {
-        rejectOperation(new Error('transport torn down'))
+        // Teardown-shaped, as a real aborted transport rejects (e.g. S3 RequestAbortedError).
+        rejectOperation(Object.assign(new Error('transport torn down'), { code: 'RequestAbortedError' }))
         throw new Error('teardown exploded')
       }
       const pending = runStoreWithSignal(source, controller.signal, () => operation, failingHook)
@@ -50,7 +51,9 @@ describe('runStoreWithSignal', () => {
       const operation = new Promise<never>((_, reject) => {
         rejectOperation = reject
       })
-      hookCalled = jest.fn(() => rejectOperation(new Error('transport torn down')))
+      hookCalled = jest.fn(() =>
+        rejectOperation(Object.assign(new Error('transport torn down'), { code: 'RequestAbortedError' }))
+      )
       const pending = runStoreWithSignal(source, controller.signal, () => operation, hookCalled)
       controller.abort(reason)
       outcome = await pending.then(
@@ -64,6 +67,61 @@ describe('runStoreWithSignal', () => {
     })
 
     it('should reject with the abort reason', () => {
+      expect(outcome).toBe(reason)
+    })
+  })
+
+  describe('when a real failure races the abort', () => {
+    let diskFullError: Error
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // The operation fails for a reason the teardown did not cause (ENOSPC) while the signal
+      // aborts: the real storage error must surface as itself, not as the cancellation reason.
+      diskFullError = Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
+      const controller = new AbortController()
+      const source = new Readable({ read() {} })
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      const pending = runStoreWithSignal(source, controller.signal, () => operation)
+      controller.abort(new Error('cancelled'))
+      rejectOperation(diskFullError)
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should surface the real error instead of the cancellation reason', () => {
+      expect(outcome).toBe(diskFullError)
+    })
+  })
+
+  describe('when the destroyed source rejects with a premature close', () => {
+    let reason: Error
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // The teardown-caused rejection shape (a destroyed source) IS translated to the reason.
+      reason = new Error('cancelled')
+      const controller = new AbortController()
+      const source = new Readable({ read() {} })
+      let rejectOperation: (error: Error) => void = () => undefined
+      const operation = new Promise<never>((_, reject) => {
+        rejectOperation = reject
+      })
+      const pending = runStoreWithSignal(source, controller.signal, () => operation)
+      controller.abort(reason)
+      rejectOperation(Object.assign(new Error('Premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))
+      outcome = await pending.then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should reject with the cancellation reason', () => {
       expect(outcome).toBe(reason)
     })
   })

--- a/test/compression.spec.ts
+++ b/test/compression.spec.ts
@@ -14,6 +14,36 @@ describe('compressContentFile', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
+  describe('when the signal is already aborted', () => {
+    let input: string
+    let outcome: 'resolved' | unknown
+
+    beforeEach(async () => {
+      // The signal reaches the read→gzip→write pipeline itself: an abort tears the streams down
+      // instead of letting the compression run to completion for a cancelled request.
+      input = path.join(dir, 'aborted-compressible')
+      await nodeFs.writeFile(input, Buffer.alloc(100000, 0))
+      const controller = new AbortController()
+      controller.abort()
+      outcome = await compressContentFile(input, undefined, undefined, controller.signal).then(
+        () => 'resolved' as const,
+        (error: unknown) => error
+      )
+    })
+
+    it('should reject with an abort error', () => {
+      expect((outcome as Error).name).toBe('AbortError')
+    })
+
+    it('should remove the partial output', () => {
+      expect(existsSync(input + '.gzip')).toBe(false)
+    })
+
+    it('should leave the input intact', async () => {
+      expect((await nodeFs.stat(input)).size).toBe(100000)
+    })
+  })
+
   it(`When the content compresses well, then a .gzip is produced`, async () => {
     const input = path.join(dir, 'compressible')
     await nodeFs.writeFile(input, Buffer.alloc(1000, 0))

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1129,6 +1129,62 @@ describe('fileSystemContentStorage', () => {
       })
     })
 
+    describe('when the signal aborts during the counterpart check of a fresh id', () => {
+      let freshAbortRoot: string
+      let reason: Error
+      let storeOutcome: 'resolved' | unknown
+      let freshAbortStorage: IContentStorageComponent
+
+      beforeEach(async () => {
+        // A fresh id has no counterpart: no intent is journaled, so the intent-cleanup checkpoint
+        // is skipped — only the unconditional pre-rename checkpoint can stop the commit when the
+        // abort lands during the awaited counterpart existence check.
+        freshAbortRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-fresh-abort-'))
+        const counterpartPath = path.join(freshAbortRoot, '9584', id) + '.gzip'
+        const realFs = createFsComponent()
+        const controller = new AbortController()
+        reason = new Error('cancelled during the counterpart check')
+        const abortingFs: IFileSystemComponent = {
+          ...realFs,
+          stat: (async (target: any) => {
+            if (String(target) === counterpartPath) {
+              // The abort lands inside this await; the check itself reports "absent" as reality would.
+              controller.abort(reason)
+            }
+            return realFs.stat(target)
+          }) as typeof realFs.stat
+        }
+        freshAbortStorage = await createFolderBasedFileSystemContentStorage(
+          { fs: abortingFs, logs: await createLogComponent({}) },
+          freshAbortRoot
+        )
+        storeOutcome = await freshAbortStorage.storeStream(id, bufferToStream(content), controller.signal).then(
+          () => 'resolved' as const,
+          (error: unknown) => error
+        )
+      })
+
+      afterEach(async () => {
+        await freshAbortStorage.stop?.()
+        rmSync(freshAbortRoot, { recursive: true, force: true })
+      })
+
+      it('should reject with the abort reason instead of committing the fresh object', () => {
+        expect(storeOutcome).toBe(reason)
+      })
+
+      it('should not commit anything', async () => {
+        expect(await freshAbortStorage.exist(id)).toBe(false)
+      })
+
+      it('should leave no staged residue', async () => {
+        const staged = (await nodeFs.readdir(path.join(freshAbortRoot, '.tmp-writes'))).filter((entry) =>
+          /^[0-9a-f]{16}-[0-9a-f]{32}$/.test(entry)
+        )
+        expect(staged).toEqual([])
+      })
+    })
+
     describe('when the signal aborts during the pre-rename work inside the commit', () => {
       let preRenameRoot: string
       let previousBytes: Buffer

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -3430,6 +3430,102 @@ describe('fileSystemContentStorage', () => {
         })
       })
 
+      describe('and a real compression failure races a caller abort', () => {
+        let rawBytes: Buffer
+        let diskFullError: Error
+        let compressSpy: jest.SpyInstance
+        let storeOutcome: 'resolved' | unknown
+
+        beforeEach(async () => {
+          // The compression fails for a real reason (ENOSPC) while the caller happens to abort:
+          // suppressing it would misreport a failed compressed store as success, and leaving it
+          // unmarked would hide it behind the cancellation reason. It must surface as-is.
+          rawBytes = Buffer.from(new Uint8Array(64).fill(7))
+          diskFullError = Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
+          const controller = new AbortController()
+          compressSpy = jest.spyOn(compressionModule, 'compressContentFile').mockImplementationOnce(async () => {
+            controller.abort(new Error('cancelled while compression was failing'))
+            throw diskFullError
+          })
+          storeOutcome = await storageWithoutRename
+            .storeStreamAndCompress(id2, bufferToStream(rawBytes), controller.signal)
+            .then(
+              () => 'resolved' as const,
+              (error: unknown) => error
+            )
+        })
+
+        afterEach(() => {
+          compressSpy.mockRestore()
+        })
+
+        it('should reject with the real storage error, not resolve and not the abort reason', () => {
+          expect(storeOutcome).toBe(diskFullError)
+        })
+
+        it('should keep the committed raw readable', async () => {
+          const item = await storageWithoutRename.retrieve(id2)
+          expect(await streamToBuffer(await item!.asStream())).toEqual(rawBytes)
+        })
+      })
+
+      describe('and an aborted compression leaves a partial gzip that cannot be removed', () => {
+        let partialRoot: string
+        let gzipPath: string
+        let compressSpy: jest.SpyInstance
+        let storeOutcome: 'resolved' | unknown
+        let partialStorage: IContentStorageComponent
+
+        beforeEach(async () => {
+          // The teardown is abort-caused, but the partial canonical gzip survives its cleanup:
+          // resolving would let reads prefer the corrupt gzip over the committed raw, so the store
+          // must fail loudly with the invariant error — visible even past the abort translation.
+          partialRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-partial-gzip-'))
+          gzipPath = path.join(partialRoot, '9584', id) + '.gzip'
+          const realFs = createFsComponent()
+          let unlinkFails = false
+          const failingFs: IFileSystemComponent = {
+            ...realFs,
+            rename: undefined,
+            unlink: (async (target: any) => {
+              if (unlinkFails && String(target) === gzipPath) {
+                throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' })
+              }
+              return realFs.unlink(target)
+            }) as typeof realFs.unlink
+          }
+          partialStorage = await createFolderBasedFileSystemContentStorage(
+            { fs: failingFs, logs: await createLogComponent({}) },
+            partialRoot
+          )
+          const controller = new AbortController()
+          compressSpy = jest.spyOn(compressionModule, 'compressContentFile').mockImplementationOnce(async () => {
+            // Simulate a torn-down pipeline whose partial-output cleanup failed: the partial
+            // canonical gzip is left behind and stays unremovable for the store's verification.
+            await nodeFs.writeFile(gzipPath, Buffer.from('partial gzip bytes'))
+            unlinkFails = true
+            controller.abort(new Error('cancelled mid-compression'))
+            throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+          })
+          storeOutcome = await partialStorage
+            .storeStreamAndCompress(id, bufferToStream(Buffer.from(new Uint8Array(64).fill(1))), controller.signal)
+            .then(
+              () => 'resolved' as const,
+              (error: unknown) => error
+            )
+        })
+
+        afterEach(async () => {
+          compressSpy.mockRestore()
+          await partialStorage.stop?.()
+          rmSync(partialRoot, { recursive: true, force: true })
+        })
+
+        it('should reject with the invariant error instead of resolving over a corrupt gzip', () => {
+          expect((storeOutcome as Error).message).toContain('could not be removed')
+        })
+      })
+
       describe('and the gzip cleanup of an in-place store fails', () => {
         let legacyRoot: string
         let originalBytes: Buffer

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto'
 import { mkdtempSync, promises as nodeFs, rmSync } from 'fs'
 import os from 'os'
 import path from 'path'
-import { PassThrough, Readable } from 'stream'
+import { PassThrough, Readable, Writable } from 'stream'
 import { gzipSync } from 'zlib'
 import {
   createFolderBasedFileSystemContentStorage,
@@ -1073,6 +1073,59 @@ describe('fileSystemContentStorage', () => {
         await customStorage.storeStream('.tmp-writes', bufferToStream(content))
         const item = await customStorage.retrieve('.tmp-writes')
         expect(await streamToBuffer(await item!.asStream())).toEqual(content)
+      })
+    })
+
+    describe('when the staged write fails for a real reason while the caller aborts', () => {
+      let enospcRoot: string
+      let diskFullError: Error
+      let storeOutcome: 'resolved' | unknown
+      let enospcStorage: IContentStorageComponent
+
+      beforeEach(async () => {
+        // The staged write fails with ENOSPC while the caller happens to abort: the real storage
+        // error is not teardown-caused and must surface as itself, not as the cancellation reason.
+        enospcRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-enospc-race-'))
+        diskFullError = Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' })
+        const controller = new AbortController()
+        const realFs = createFsComponent()
+        let armed = true
+        const failingFs: IFileSystemComponent = {
+          ...realFs,
+          createWriteStream: ((target: any, opts?: any) => {
+            if (armed && /[0-9a-f]{16}-[0-9a-f]{32}$/.test(String(target))) {
+              armed = false
+              return new Writable({
+                write(_chunk, _encoding, callback) {
+                  controller.abort(new Error('cancelled while the disk was filling up'))
+                  callback(diskFullError)
+                }
+              }) as any
+            }
+            return realFs.createWriteStream(target, opts)
+          }) as typeof realFs.createWriteStream
+        }
+        enospcStorage = await createFolderBasedFileSystemContentStorage(
+          { fs: failingFs, logs: await createLogComponent({}) },
+          enospcRoot
+        )
+        storeOutcome = await enospcStorage.storeStream(id, bufferToStream(content), controller.signal).then(
+          () => 'resolved' as const,
+          (error: unknown) => error
+        )
+      })
+
+      afterEach(async () => {
+        await enospcStorage.stop?.()
+        rmSync(enospcRoot, { recursive: true, force: true })
+      })
+
+      it('should surface the real storage error instead of the cancellation reason', () => {
+        expect(storeOutcome).toBe(diskFullError)
+      })
+
+      it('should not commit anything', async () => {
+        expect(await enospcStorage.exist(id)).toBe(false)
       })
     })
 

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1076,6 +1076,61 @@ describe('fileSystemContentStorage', () => {
       })
     })
 
+    describe('when the signal aborts while the commit itself fails', () => {
+      let maskingRoot: string
+      let reason: Error
+      let storeOutcome: 'resolved' | unknown
+      let failingStorage: IContentStorageComponent
+
+      beforeEach(async () => {
+        // The abort lands DURING an irreversible commit whose counterpart cleanup fails: the
+        // resulting committed-but-unreconciled error (quarantine) is a real storage failure that
+        // operators need to see — the cancellation translation must not mask it behind the abort
+        // reason.
+        maskingRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-abort-masking-'))
+        const gzipPath = path.join(maskingRoot, '9584', id) + '.gzip'
+        const realFs = createFsComponent()
+        const controller = new AbortController()
+        reason = new Error('cancelled during the commit')
+        let armed = false
+        const failingFs: IFileSystemComponent = {
+          ...realFs,
+          unlink: (async (target: any) => {
+            if (armed && String(target) === gzipPath) {
+              armed = false
+              // The abort arrives exactly while the commit's counterpart cleanup is failing.
+              controller.abort(reason)
+              throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' })
+            }
+            return realFs.unlink(target)
+          }) as typeof realFs.unlink
+        }
+        failingStorage = await createFolderBasedFileSystemContentStorage(
+          { fs: failingFs, logs: await createLogComponent({}) },
+          maskingRoot
+        )
+        await failingStorage.storeStreamAndCompress(id, bufferToStream(Buffer.from(new Uint8Array(100).fill(5))))
+        armed = true
+        storeOutcome = await failingStorage.storeStream(id, bufferToStream(content), controller.signal).then(
+          () => 'resolved' as const,
+          (error: unknown) => error
+        )
+      })
+
+      afterEach(async () => {
+        await failingStorage.stop?.()
+        rmSync(maskingRoot, { recursive: true, force: true })
+      })
+
+      it('should surface the quarantine error instead of the abort reason', () => {
+        expect((storeOutcome as Error).message).toContain('quarantined')
+      })
+
+      it('should not reject with the cancellation reason', () => {
+        expect(storeOutcome).not.toBe(reason)
+      })
+    })
+
     describe('when the signal aborts while the store is queued on the path lock', () => {
       let lockRoot: string
       let firstWriterBytes: Buffer
@@ -3335,6 +3390,43 @@ describe('fileSystemContentStorage', () => {
         it('should keep the previous version intact', async () => {
           const item = await storageWithoutRename.retrieve(id2)
           expect(await streamToBuffer(await item!.asStream())).toEqual(previousBytes)
+        })
+      })
+
+      describe('and the signal tears the compression down after the in-place raw commit', () => {
+        let rawBytes: Buffer
+        let compressSpy: jest.SpyInstance
+        let storeOutcome: 'resolved' | unknown
+
+        beforeEach(async () => {
+          // The abort tears the compression pipeline down mid-flight — but the in-place raw commit
+          // already completed, so the store must resolve with the raw as primary instead of
+          // rejecting an already-completed store.
+          rawBytes = Buffer.from(new Uint8Array(64).fill(9))
+          const controller = new AbortController()
+          compressSpy = jest.spyOn(compressionModule, 'compressContentFile').mockImplementationOnce(async () => {
+            controller.abort(new Error('cancelled mid-compression'))
+            throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+          })
+          storeOutcome = await storageWithoutRename
+            .storeStreamAndCompress(id2, bufferToStream(rawBytes), controller.signal)
+            .then(
+              () => 'resolved' as const,
+              (error: unknown) => error
+            )
+        })
+
+        afterEach(() => {
+          compressSpy.mockRestore()
+        })
+
+        it('should treat the store as completed', () => {
+          expect(storeOutcome).toBe('resolved')
+        })
+
+        it('should keep the raw as the primary representation', async () => {
+          const item = await storageWithoutRename.retrieve(id2)
+          expect(await streamToBuffer(await item!.asStream())).toEqual(rawBytes)
         })
       })
 

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1434,6 +1434,47 @@ describe('fileSystemContentStorage', () => {
       })
     })
 
+    describe('when the signalled compression pipeline is torn down by the abort', () => {
+      let compressSpy: jest.SpyInstance
+      let reason: Error
+      let storeOutcome: 'resolved' | unknown
+
+      beforeEach(async () => {
+        // The staged path hands the signal to the compression pipeline, so an abort-shaped rejection
+        // from it is provably this cancellation's own teardown: the caller must observe THEIR reason,
+        // not the pipeline's AbortError — this is the attribution the generic translation no longer
+        // makes on shape alone.
+        reason = new Error('cancelled mid-compression pipeline')
+        const controller = new AbortController()
+        compressSpy = jest.spyOn(compressionModule, 'compressContentFile').mockImplementationOnce(async () => {
+          controller.abort(reason)
+          throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError', code: 'ABORT_ERR' })
+        })
+        storeOutcome = await fileSystemContentStorage
+          .storeStreamAndCompress(
+            'signalled-compression',
+            bufferToStream(Buffer.from(new Uint8Array(100).fill(0))),
+            controller.signal
+          )
+          .then(
+            () => 'resolved' as const,
+            (error: unknown) => error
+          )
+      })
+
+      afterEach(() => {
+        compressSpy.mockRestore()
+      })
+
+      it('should reject with the caller reason rather than the pipeline abort error', () => {
+        expect(storeOutcome).toBe(reason)
+      })
+
+      it('should not commit the object', async () => {
+        expect(await fileSystemContentStorage.exist('signalled-compression')).toBe(false)
+      })
+    })
+
     describe('when the compression of a staged store fails', () => {
       let compressSpy: jest.SpyInstance
       let storeOutcome: 'resolved' | Error

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1076,6 +1076,50 @@ describe('fileSystemContentStorage', () => {
       })
     })
 
+    describe('when the signal aborts after the source was fully consumed', () => {
+      let compressSpy: jest.SpyInstance
+      let reason: Error
+      let storeOutcome: 'resolved' | unknown
+
+      beforeEach(async () => {
+        // The source has been consumed, so destroying it does nothing — the abort is observed
+        // during the compression phase. The store must stop at the next checkpoint and reject with
+        // the caller's reason instead of continuing the expensive work and committing the object.
+        reason = new Error('cancelled after the source ended')
+        const controller = new AbortController()
+        compressSpy = jest.spyOn(compressionModule, 'compressContentFile').mockImplementationOnce(async () => {
+          controller.abort(reason)
+          return true
+        })
+        storeOutcome = await fileSystemContentStorage
+          .storeStreamAndCompress(
+            'signal-consumed',
+            bufferToStream(Buffer.from(new Uint8Array(100).fill(0))),
+            controller.signal
+          )
+          .then(
+            () => 'resolved' as const,
+            (error: unknown) => error
+          )
+      })
+
+      afterEach(() => {
+        compressSpy.mockRestore()
+      })
+
+      it('should reject with the abort reason', () => {
+        expect(storeOutcome).toBe(reason)
+      })
+
+      it('should not commit the object', async () => {
+        expect(await fileSystemContentStorage.exist('signal-consumed')).toBe(false)
+      })
+
+      it('should leave no staging residue', async () => {
+        expect(await nodeFs.readdir(path.join(tmpRootDir, '.tmp-writes'))).toEqual([])
+      })
+    })
+
     describe('when the compression of a staged store fails', () => {
       let compressSpy: jest.SpyInstance
       let storeOutcome: 'resolved' | Error

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1236,6 +1236,12 @@ describe('fileSystemContentStorage', () => {
         expect(await streamToBuffer(await item!.asStream())).toEqual(previousBytes)
       })
 
+      it('should not tag the caller-owned abort reason with internal markers', () => {
+        // The commit phase's checkpoints throw the caller's reason; the commit wrapper must not
+        // brand that caller-owned object with this module's internal non-cancellation symbol.
+        expect(Object.getOwnPropertySymbols(reason)).toEqual([])
+      })
+
       it('should discard the just-written intent so no repair can apply it', async () => {
         const entries = await nodeFs.readdir(path.join(preRenameRoot, '.tmp-writes'))
         expect(entries.filter((entry) => entry.endsWith('.intent'))).toEqual([])

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1076,6 +1076,86 @@ describe('fileSystemContentStorage', () => {
       })
     })
 
+    describe('when the signal aborts while the store is queued on the path lock', () => {
+      let lockRoot: string
+      let firstWriterBytes: Buffer
+      let reason: Error
+      let queuedOutcome: 'resolved' | unknown
+      let lockedStorage: IContentStorageComponent
+
+      beforeEach(async () => {
+        // Writer A holds the path lock (its commit rename is gated); writer B consumes its source,
+        // passes the pre-lock checkpoint and queues on the lock. The abort lands while B is queued
+        // — with the source already consumed, only the inside-lock checkpoint can stop the commit.
+        lockRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-lock-abort-'))
+        const rawPath = path.join(lockRoot, '9584', id)
+        const realFs = createFsComponent()
+        let releaseRename: () => void = () => undefined
+        const renameGate = new Promise<void>((res) => (releaseRename = res))
+        let renameStarted: () => void = () => undefined
+        const renameStartedPromise = new Promise<void>((res) => (renameStarted = res))
+        let holdNextRename = true
+        const gatedFs: IFileSystemComponent = {
+          ...realFs,
+          rename: (async (from: any, to: any) => {
+            if (String(to) === rawPath && holdNextRename) {
+              holdNextRename = false
+              renameStarted()
+              await renameGate
+            }
+            return realFs.rename!(from, to)
+          }) as typeof realFs.rename
+        }
+        lockedStorage = await createFolderBasedFileSystemContentStorage(
+          { fs: gatedFs, logs: await createLogComponent({}) },
+          lockRoot
+        )
+        firstWriterBytes = Buffer.from('first writer bytes')
+        const firstStore = lockedStorage.storeStream(id, bufferToStream(firstWriterBytes))
+        await renameStartedPromise
+        reason = new Error('cancelled while queued on the lock')
+        const controller = new AbortController()
+        const queuedStore = lockedStorage.storeStream(id, bufferToStream(content), controller.signal)
+        // Let the queued store consume its source and reach the lock queue.
+        const tempDirPath = path.join(lockRoot, '.tmp-writes')
+        for (let i = 0; i < 1000; i++) {
+          const staged = (await nodeFs.readdir(tempDirPath)).filter((entry) =>
+            /^[0-9a-f]{16}-[0-9a-f]{32}$/.test(entry)
+          )
+          if (staged.length >= 2) break
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        controller.abort(reason)
+        releaseRename()
+        await firstStore
+        queuedOutcome = await queuedStore.then(
+          () => 'resolved' as const,
+          (error: unknown) => error
+        )
+      })
+
+      afterEach(async () => {
+        await lockedStorage.stop?.()
+        rmSync(lockRoot, { recursive: true, force: true })
+      })
+
+      it('should reject the queued store with the abort reason', () => {
+        expect(queuedOutcome).toBe(reason)
+      })
+
+      it('should keep the first writer content as the committed version', async () => {
+        const item = await lockedStorage.retrieve(id)
+        expect(await streamToBuffer(await item!.asStream())).toEqual(firstWriterBytes)
+      })
+
+      it('should leave no staging residue', async () => {
+        const staged = (await nodeFs.readdir(path.join(lockRoot, '.tmp-writes'))).filter((entry) =>
+          /^[0-9a-f]{16}-[0-9a-f]{32}$/.test(entry)
+        )
+        expect(staged).toEqual([])
+      })
+    })
+
     describe('when the signal aborts after the source was fully consumed', () => {
       let compressSpy: jest.SpyInstance
       let reason: Error
@@ -3160,6 +3240,101 @@ describe('fileSystemContentStorage', () => {
 
         it('should not leave the compressed store gzip shadowing the later raw', async () => {
           expect(await fs.existPath(filePath2 + '.gzip')).toBe(false)
+        })
+      })
+
+      describe('and the signal aborts after the in-place write has replaced the previous raw', () => {
+        let inPlaceRoot: string
+        let newBytes: Buffer
+        let storeOutcome: 'resolved' | unknown
+        let inPlaceStorage: IContentStorageComponent
+
+        beforeEach(async () => {
+          // The in-place pipe has already overwritten the previous raw when the abort is observed:
+          // "rolling back" would unlink the only committed object (the previous version is
+          // unrecoverable without rename support), so the store must be treated as COMPLETED — the
+          // regression was cancellation deleting an existing raw-backed id entirely.
+          inPlaceRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-inplace-abort-'))
+          const gzipPath = path.join(inPlaceRoot, '9584', id) + '.gzip'
+          const realFs = createFsComponent()
+          const controller = new AbortController()
+          let armed = false
+          const abortingFs: IFileSystemComponent = {
+            ...realFs,
+            rename: undefined,
+            unlink: (async (target: any) => {
+              // The gzip cleanup runs right after the pipe: abort exactly there (post-write).
+              if (armed && String(target) === gzipPath) {
+                armed = false
+                controller.abort(new Error('cancelled after the in-place write'))
+              }
+              return realFs.unlink(target)
+            }) as typeof realFs.unlink
+          }
+          inPlaceStorage = await createFolderBasedFileSystemContentStorage(
+            { fs: abortingFs, logs: await createLogComponent({}) },
+            inPlaceRoot
+          )
+          await inPlaceStorage.storeStream(id, bufferToStream(Buffer.from('previous raw version')))
+          newBytes = Buffer.from('new raw version')
+          armed = true
+          storeOutcome = await inPlaceStorage.storeStream(id, bufferToStream(newBytes), controller.signal).then(
+            () => 'resolved' as const,
+            (error: unknown) => error
+          )
+        })
+
+        afterEach(async () => {
+          await inPlaceStorage.stop?.()
+          rmSync(inPlaceRoot, { recursive: true, force: true })
+        })
+
+        it('should treat the store as completed', () => {
+          expect(storeOutcome).toBe('resolved')
+        })
+
+        it('should keep the id readable with the new content instead of deleting it', async () => {
+          const item = await inPlaceStorage.retrieve(id)
+          expect(await streamToBuffer(await item!.asStream())).toEqual(newBytes)
+        })
+      })
+
+      describe('and the signal aborts while an in-place store is queued on the path lock', () => {
+        let previousBytes: Buffer
+        let reason: Error
+        let queuedOutcome: 'resolved' | unknown
+
+        beforeEach(async () => {
+          // Cancellation in no-rename mode is honored BEFORE the destructive write begins: writer A
+          // holds the lock for its whole in-place write (gated source), writer B queues, the abort
+          // lands, and B must reject at the pre-write checkpoint with A's version intact.
+          previousBytes = Buffer.from(new Uint8Array(64).fill(3))
+          const gatedSource = new Readable({ read() {} })
+          const firstStore = storageWithoutRename.storeStream(id2, gatedSource)
+          // Wait until A has opened the destination — proof it holds the lock mid-write.
+          for (let i = 0; i < 1000 && !(await fs.existPath(filePath2)); i++) {
+            // each awaited existPath yields an event-loop turn
+          }
+          reason = new Error('cancelled while queued behind an in-place write')
+          const controller = new AbortController()
+          const queuedStore = storageWithoutRename.storeStream(id2, bufferToStream(content2), controller.signal)
+          controller.abort(reason)
+          gatedSource.push(previousBytes)
+          gatedSource.push(null)
+          await firstStore
+          queuedOutcome = await queuedStore.then(
+            () => 'resolved' as const,
+            (error: unknown) => error
+          )
+        })
+
+        it('should reject the queued store with the abort reason', () => {
+          expect(queuedOutcome).toBe(reason)
+        })
+
+        it('should keep the previous version intact', async () => {
+          const item = await storageWithoutRename.retrieve(id2)
+          expect(await streamToBuffer(await item!.asStream())).toEqual(previousBytes)
         })
       })
 

--- a/test/file-system-content-storage.spec.ts
+++ b/test/file-system-content-storage.spec.ts
@@ -1129,6 +1129,70 @@ describe('fileSystemContentStorage', () => {
       })
     })
 
+    describe('when the signal aborts during the pre-rename work inside the commit', () => {
+      let preRenameRoot: string
+      let previousBytes: Buffer
+      let reason: Error
+      let storeOutcome: 'resolved' | unknown
+      let preRenameStorage: IContentStorageComponent
+
+      beforeEach(async () => {
+        // The abort lands while the commit is journaling its intent — after every earlier
+        // checkpoint, with the source long consumed. The commit must still cancel before the
+        // irreversible rename, discarding the just-written journal so no repair can ever apply it.
+        preRenameRoot = mkdtempSync(path.join(os.tmpdir(), 'cs-pre-rename-abort-'))
+        const realFs = createFsComponent()
+        const controller = new AbortController()
+        reason = new Error('cancelled while the intent was being journaled')
+        const abortingFs: IFileSystemComponent = {
+          ...realFs,
+          createWriteStream: ((target: any, opts?: any) => {
+            if (String(target).endsWith('.intent')) {
+              controller.abort(reason)
+            }
+            return realFs.createWriteStream(target, opts)
+          }) as typeof realFs.createWriteStream
+        }
+        preRenameStorage = await createFolderBasedFileSystemContentStorage(
+          { fs: abortingFs, logs: await createLogComponent({}) },
+          preRenameRoot
+        )
+        // A gzip primary, so the raw commit below has a counterpart and journals an intent.
+        previousBytes = Buffer.from(new Uint8Array(100).fill(5))
+        await preRenameStorage.storeStreamAndCompress(id, bufferToStream(previousBytes))
+        storeOutcome = await preRenameStorage.storeStream(id, bufferToStream(content), controller.signal).then(
+          () => 'resolved' as const,
+          (error: unknown) => error
+        )
+      })
+
+      afterEach(async () => {
+        await preRenameStorage.stop?.()
+        rmSync(preRenameRoot, { recursive: true, force: true })
+      })
+
+      it('should reject with the abort reason instead of committing', () => {
+        expect(storeOutcome).toBe(reason)
+      })
+
+      it('should keep serving the previous version', async () => {
+        const item = await preRenameStorage.retrieve(id)
+        expect(await streamToBuffer(await item!.asStream())).toEqual(previousBytes)
+      })
+
+      it('should discard the just-written intent so no repair can apply it', async () => {
+        const entries = await nodeFs.readdir(path.join(preRenameRoot, '.tmp-writes'))
+        expect(entries.filter((entry) => entry.endsWith('.intent'))).toEqual([])
+      })
+
+      it('should leave no staged residue', async () => {
+        const staged = (await nodeFs.readdir(path.join(preRenameRoot, '.tmp-writes'))).filter((entry) =>
+          /^[0-9a-f]{16}-[0-9a-f]{32}$/.test(entry)
+        )
+        expect(staged).toEqual([])
+      })
+    })
+
     describe('when the signal aborts while the commit itself fails', () => {
       let maskingRoot: string
       let reason: Error

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -481,6 +481,30 @@ describe('S3 Storage upload cancellation', () => {
     await expect(storage.storeStream('destroy-throws-id', source)).rejects.toBe(uploadFault)
   })
 
+  it(`When an S3-compatible abort() throws during upload creation, then the caller still sees the reason`, async () => {
+    // The manual teardown in the post-creation checkpoint must be as exception-safe as the listener's
+    // hook: a throwing abort() cannot be allowed to replace the caller's cancellation reason.
+    const logs = await createLogComponent({})
+    const controller = new AbortController()
+    const reason = new Error('cancelled during upload creation')
+    const promiseSpy = jest.fn(() => new Promise<never>(() => undefined))
+    const upload = jest.fn(() => {
+      controller.abort(reason)
+      return {
+        promise: promiseSpy,
+        abort: () => {
+          throw new Error('abort exploded')
+        }
+      }
+    })
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, { upload } as any, { Bucket: 'example' })
+
+    await expect(
+      storage.storeStream('abort-throws-id', bufferToStream(Buffer.from('small')), controller.signal)
+    ).rejects.toBe(reason)
+    expect(promiseSpy).not.toHaveBeenCalled()
+  })
+
   it(`When the signal aborts during upload creation, then the upload is torn down before it is awaited`, async () => {
     // The abort listener can only call ManagedUpload.abort() once the upload variable is assigned:
     // an abort firing during s3.upload(...) itself finds it undefined, and with a small source

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -426,4 +426,27 @@ describe('S3 Storage upload cancellation', () => {
     await expect(pending).rejects.toBe(reason)
     expect(abort).toHaveBeenCalledTimes(1)
   })
+
+  it(`When the signal aborts during upload creation, then the upload is torn down before it is awaited`, async () => {
+    // The abort listener can only call ManagedUpload.abort() once the upload variable is assigned:
+    // an abort firing during s3.upload(...) itself finds it undefined, and with a small source
+    // already buffered into the head, the upload would otherwise complete for a cancelled store.
+    const logs = await createLogComponent({})
+    const controller = new AbortController()
+    const reason = new Error('cancelled during upload creation')
+    const abort = jest.fn()
+    const promiseSpy = jest.fn(() => new Promise<never>(() => undefined))
+    const upload = jest.fn(() => {
+      // Fires while the caller's `upload` variable is still unassigned.
+      controller.abort(reason)
+      return { promise: promiseSpy, abort }
+    })
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, { upload } as any, { Bucket: 'example' })
+
+    const pending = storage.storeStream('creation-abort-id', bufferToStream(Buffer.from('small')), controller.signal)
+
+    await expect(pending).rejects.toBe(reason)
+    expect(abort).toHaveBeenCalledTimes(1)
+    expect(promiseSpy).not.toHaveBeenCalled()
+  })
 })

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -396,3 +396,34 @@ describe('S3 Storage retrieve error logging', () => {
     expect(logger.error.mock.calls[0][1]).toMatchObject({ key: 'some-key', code: 'InternalError' })
   })
 })
+
+describe('S3 Storage upload cancellation', () => {
+  it(`When the signal aborts while the upload is in flight, then the managed upload is aborted and the call rejects with the reason`, async () => {
+    const logs = await createLogComponent({})
+    let rejectUpload: (error: Error) => void = () => undefined
+    const abort = jest.fn(() =>
+      rejectUpload(Object.assign(new Error('Request aborted by user'), { code: 'RequestAbortedError' }))
+    )
+    const upload = jest.fn(() => ({
+      promise: () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectUpload = reject
+        }),
+      abort
+    }))
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, { upload } as any, { Bucket: 'example' })
+    const controller = new AbortController()
+    const reason = new Error('deployment deadline exceeded')
+
+    // Larger than the MIME-detection window so the store is genuinely mid-upload when aborted, and
+    // fully buffered by the fake SDK, so destroying the source alone could never settle the call.
+    const pending = storage.storeStream('wedged-id', bufferToStream(Buffer.alloc(5000, 1)), controller.signal)
+    while (upload.mock.calls.length === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+    controller.abort(reason)
+
+    await expect(pending).rejects.toBe(reason)
+    expect(abort).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/s3-based-storage-component.spec.ts
+++ b/test/s3-based-storage-component.spec.ts
@@ -427,6 +427,60 @@ describe('S3 Storage upload cancellation', () => {
     expect(abort).toHaveBeenCalledTimes(1)
   })
 
+  it(`When the SDK reports an aborted request the hook did not cause, then the real error surfaces`, async () => {
+    // RequestAbortedError is a public SDK shape: an SDK-internal socket teardown can produce it and
+    // merely race the caller's cancellation. Without our own abort being the cause (this double has
+    // no abort(), so the hook tears nothing down), the real failure must not be reported as the
+    // caller's cancellation reason.
+    const logs = await createLogComponent({})
+    const controller = new AbortController()
+    const sdkFault = Object.assign(new Error('Request aborted by the socket'), { code: 'RequestAbortedError' })
+    let rejectUpload: (error: Error) => void = () => undefined
+    const upload = jest.fn(() => ({
+      promise: () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectUpload = reject
+        })
+      // deliberately no abort(): the teardown hook cannot tear this upload down
+    }))
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, { upload } as any, { Bucket: 'example' })
+
+    const pending = storage.storeStream('sdk-fault-id', bufferToStream(Buffer.alloc(5000, 1)), controller.signal)
+    while (upload.mock.calls.length === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+    controller.abort(new Error('cancelled while the socket was failing'))
+    rejectUpload(sdkFault)
+
+    await expect(pending).rejects.toBe(sdkFault)
+  })
+
+  it(`When the upload fails and the source destroy throws, then the upload error is preserved`, async () => {
+    const logs = await createLogComponent({})
+    const uploadFault = Object.assign(new Error('AccessDenied'), { code: 'AccessDenied' })
+    let uploadRejected = false
+    const upload = jest.fn(() => ({
+      promise: async () => {
+        uploadRejected = true
+        throw uploadFault
+      },
+      abort: jest.fn()
+    }))
+    const storage = await createS3BasedFileSystemContentStorage({ logs }, { upload } as any, { Bucket: 'example' })
+    const source = bufferToStream(Buffer.from('some content'))
+    // Throw only for the cleanup destroy after the upload failed: an unconditional override would
+    // also break the async-iterator teardown the head read performs before the upload exists.
+    const realDestroy = source.destroy.bind(source)
+    source.destroy = ((...args: unknown[]) => {
+      if (uploadRejected) {
+        throw new Error('destroy exploded')
+      }
+      return (realDestroy as (...a: unknown[]) => Readable)(...args)
+    }) as typeof source.destroy
+
+    await expect(storage.storeStream('destroy-throws-id', source)).rejects.toBe(uploadFault)
+  })
+
   it(`When the signal aborts during upload creation, then the upload is torn down before it is awaited`, async () => {
     // The abort listener can only call ManagedUpload.abort() once the upload variable is assigned:
     // an abort firing during s3.upload(...) itself finds it undefined, and with a small source


### PR DESCRIPTION
## why

in worlds-content-server production, deployment requests were found pinned for ~9 hours by s3 uploads that never settled, with no way for the caller to give up. destroying the source stream is not enough to cancel an upload: once the sdk has buffered the bytes (always, below the part size) the request no longer depends on the source, so a wedged connection keeps `upload().promise()` pending indefinitely.

this adds an optional `AbortSignal` to both store methods on all three backends. review turned the initial "destroy the source and reject" into a precise contract: **every await between "the caller cancelled" and "the object is committed" has an explicit decision, and no cancellation can mask, undo or corrupt anything.**

## the contract

- **cancellation is honored up to the commit, never past it.** destroying the source only helps while it is still being read, so each backend also checks the signal at every phase boundary after consumption: after the source pipe, after compression, while queued on the per-path lock, and inside the commit itself (after pending-intent repair, after the intent journal write, and unconditionally immediately before the irreversible rename). before every one of those checkpoints nothing canonical has been touched, so cancelling leaves the previous version of the id fully intact and removes only staging residue.
- **a store that completes before observing the abort may succeed.** content is addressed by its id, so a committed write is never harmful — and this clause is load-bearing for the legacy in-place path (below).
- **no partial content is ever observable under the id**, cancelled or not.
- **cancellation never masks a real failure.** a rejection is reported as the caller's reason only when it is *provably* caused by this cancellation's own teardown (see below); an s3 rejection, an ENOSPC on a staged write, a zlib error or an upstream premature close that merely *raced* the abort surfaces as itself.
- **cancellation never hides a storage-integrity signal.** commit-phase failures — failed counterpart cleanup, unremovable intent journal, the quarantine state from #108 — are marked non-cancellation and always surface, because operators need them even when the caller has walked away.
- **compression is abortable mid-flight**, so a cancelled request stops paying cpu/disk immediately rather than at the next checkpoint; the partial output is removed before the rejection propagates.

### legacy no-rename mode

a filesystem component without `rename` writes in place, so there is no staged copy to discard. cancellation is therefore honored **only before the destructive write begins**. an abort observed after the write **completes the store** (the previous version is already gone by in-place semantics — "rolling back" would delete the only committed object, which is data loss, not cancellation) and only skips the optional compression. a mid-write abort follows the mode's usual non-atomic handling. this caveat is documented on the interface.

## proving a rejection came from the cancellation

translation is an allowlist, not a default. a rejection becomes the caller's reason only when:

| rejection | credited because |
|---|---|
| the signal's own `reason` | thrown by our checkpoints — identity, not shape |
| `ERR_STREAM_PREMATURE_CLOSE` | **only if** the listener destroyed a still-live source |
| `RequestAbortedError` | **only if** the abort hook reported tearing the managed upload down |

no shape is credited on appearance alone, because every shape a store can reject with is public: a source can close prematurely, an sdk can report an aborted request, and a custom stream or transport can raise an `AbortError` of its own — any of which may merely coincide with a cancellation. so each is credited only when this run's teardown actually performed the corresponding action: the hook returns `true` when it aborted the upload, and the listener records whether its destroy hit a live stream (a hook that throws before reporting counts as *not* torn down, the conservative direction). the one abort the shared translator cannot attribute — the signalled compression pipeline's — is converted to the caller's reason at that call site instead, where the attribution is known. commit-phase errors carry a non-enumerable marker that overrides all of the above.

## what changed

- **`src/cancellation.ts`** (internal, not exported from `index.ts`) — `runStoreWithSignal`: destroys the source without an error (a fully-consumed source is left untouched rather than emitting an `'error'` nobody observes), runs the optional transport-teardown hook, records teardown provenance, and translates only provably teardown-caused rejections. the hook is exception-safe: source teardown and transport teardown are individually guarded, so neither can prevent the other nor escape the signal's event dispatch. an explicit `null` abort reason is preserved.
- **s3** — the hook calls `ManagedUpload.abort()` (guarded for s3-compatible doubles that omit it) and reports whether it did; the signal is re-checked immediately after the upload is created, closing the window where the listener would have found `upload` still unassigned; the upload-failure cleanup guards `stream.destroy()` so a throwing destroy cannot displace the upload error.
- **folder** — store bodies extracted to private `doStoreStream` / `doStoreStreamAndCompress` and wrapped; checkpoints threaded through the staging, lock and commit phases as described above. a cancellation observed after the intent journal was written discharges that journal through the existing must-succeed path, so no later repair can apply a commit that never happened.
- **in-memory** — both store methods share one helper that checks the signal immediately before the commit.
- **compression** — `compressContentFile` takes an optional signal, forwarded to `stream/promises` `pipeline({ signal })`.
- **`streamToBuffer`** — fixes a latent hang this work surfaced: a stream destroyed without an error emits neither `'end'` nor `'error'`, only `'close'`, leaving the promise pending forever. the rejection carries the standard premature-close code so cancellation handling can classify it without matching on messages.

## compatibility

the `signal` parameters are optional, so existing callers and external `IContentStorageComponent` implementers are unaffected, and `cancellation.ts` is internal — the public surface grows by two optional parameters and nothing else. new api requirements (`signal.throwIfAborted`, `signal.reason`, pipeline `{ signal }`) all sit inside the `@types/node ^18` baseline this package already targets; note the package declares no `engines` floor, so add one if node < 17.3 consumers matter to you.

## performance

a/b benchmarked against `main` (same machine, interleaved rounds, three configurations). **callers that pass no signal pay nothing measurable** — `runStoreWithSignal` short-circuits before any listener or allocation — and **read paths are untouched** (`retrieve`, `exist` at parity). opting in costs ~1.5 µs per store (listener add/remove, provenance record, checkpoint branches), visible only where an entire store is ~3.4 µs (in-memory 1 kb) and invisible everywhere i/o dominates.

the pass also caught a regression in this branch: `streamToBuffer`'s new `'close'` fallback built its error — with a stack capture — on *every* call, only to reject an already-settled promise, making the helper 3.2× slower (1.4 µs → 4.4 µs). that matters beyond storage, since it is public api on hot paths (catalyst reads every entity file through it; snapshots-fetcher one per entity download). settlement is now tracked and parity is restored.

## testing

338 tests. cancellation coverage spans every phase boundary and both folder modes: pre-aborted, mid-stream, post-consumption (asserted for **all three backends** in the shared behavior suite), mid-compression, queued on the path lock, during the commit's pre-rename work, during the counterpart check of a fresh id, and during upload creation. the masking guarantees have their own tests — ENOSPC racing an abort, an sdk-internal aborted request the hook did not cause, an upstream premature close that predates the abort, and a commit-phase quarantine error landing under an aborted signal — as do the legacy-mode semantics (post-write abort completes; a cancelled compression teardown leaves the raw primary and never a corrupt gzip).

