### PR TITLE
refactor: extract the recovery journal and decompress cache

### DIFF
--- a/src/folder-based-storage-component.ts
+++ b/src/folder-based-storage-component.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'crypto'
+import { createHash } from 'crypto'
 import path from 'path'
 import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
@@ -6,42 +6,11 @@ import { AppComponents, clampRange, ContentItem, FileInfo, IContentStorageCompon
 import { SimpleContentItem, streamToBuffer } from './content-item'
 import { isAbortError, markAsNonCancellationError, runStoreWithSignal } from './cancellation'
 import { compressContentFile } from './extras/compression'
+import { createFsInvariants } from './folder-based/fs-invariants'
+import { createDecompressCache } from './folder-based/decompress-cache'
+import { createIntentJournal, TEMP_DIR_NAME, UncommittedIntentSurvivedError } from './folder-based/intent-journal'
 
 const pipe = promisify(pipeline)
-
-// Thrown when a commit rename failed AND its pre-rename intent could not be cleared. The staged
-// file it names is then the only PROOF that the rename never landed: callers must preserve that
-// exact path (instead of their usual staging cleanup), so the next construction can discard the
-// intent as pre-rename instead of applying the failed commit as a completed transition.
-class UncommittedIntentSurvivedError extends Error {
-  constructor(
-    readonly stagedPath: string,
-    message: string
-  ) {
-    super(message)
-  }
-}
-
-// Reserved directory (under the storage root) where an atomic `storeStream` stages its temp file
-// before renaming it into place. Kept out of the content namespace — a shard is a 4-hex directory and
-// content lives in files, never here — so a temp can never collide with, hide, or be mistaken for an
-// addressable id. Skipped by `allFileIds` and cleaned at startup. Its name is therefore reserved.
-const TEMP_DIR_NAME = '.tmp-writes'
-
-// Matches exactly the names newTempPath generates (`<16-hex bootId>-<32-hex random>`). The startup
-// sweep deletes ONLY files of this shape: anything else under the reserved dir is not ours to
-// remove — in flat (disablePrefixHash) mode a deployment that predates the reservation may hold
-// legitimate content there, and deleting unrecognized files would turn an upgrade into data loss.
-const STAGED_FILE_NAME = /^[0-9a-f]{16}-[0-9a-f]{32}$/
-
-// Matches the intent-journal files a representation-transition commit writes (`<40-hex
-// sha1(id)>.intent`). An intent records which representation (raw|gzip) is the NEW primary for an
-// id, so a crash between the commit rename and the counterpart cleanup is reconciled at the next
-// construction instead of leaving mixed versions that reads could prefer. The path is a
-// deterministic function of the id: at most one intent can ever exist per id (commits are
-// serialized per path, and construction reconciles before any write), so reconciliation needs no
-// ordering heuristics.
-const INTENT_FILE_NAME = /^[0-9a-f]{40}\.intent$/
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000
@@ -100,11 +69,14 @@ function createSizeLimitTransform(maxBytes: number): Transform {
 /**
  * Filesystem-backed content storage.
  *
+ * The crash-recovery journal and the decompress cache live in `./folder-based/`; this module is the
+ * storage surface over them.
+ *
  * Operational contract:
  * - **Exclusive root ownership** — a storage root must be owned by exactly one live storage
- *   instance. In-memory state (path locks, decompress-cache tracking, staged-write ownership) is
- *   per-instance; two instances over one root can delete each other's staged files and race their
- *   caches. Shared roots are not supported.
+ *   instance. In-memory state (path locks, decompress-cache tracking, staged-write ownership,
+ *   directory tracking) is per-instance; two instances over one root can delete each other's staged
+ *   files and race their caches. Shared roots are not supported.
  * - **Crash-atomic writes require `fs.rename`** — when the filesystem component provides `rename`,
  *   every write stages into a reserved directory and renames into place, so an interrupted write
  *   can never leave a partial file at a canonical path. Without `rename` (legacy custom adapters)
@@ -176,541 +148,19 @@ export async function createFolderBasedFileSystemContentStorage(
     )
   }
 
-  await components.fs.mkdir(root, { recursive: true })
+  const { existsForInvariant, noFailUnlink } = createFsInvariants(components.fs)
 
-  if (ATOMIC_MODE) {
-    // stat() follows symlinks, so a pre-existing symlink at the reserved path would pass the
-    // directory check below and route staged writes and the startup sweep OUTSIDE the storage
-    // root. Refuse it when the fs component can detect it (lstat is optional for custom adapters;
-    // without it, the documented exclusive-root operational model is the guarantee).
-    if (components.fs.lstat) {
-      let linkStat
-      try {
-        linkStat = await components.fs.lstat(tempDir)
-      } catch {
-        linkStat = undefined
-      }
-      if (linkStat?.isSymbolicLink()) {
-        throw new Error(
-          `Refusing to start: the reserved temp path '${tempDirName}' is a symbolic link; staged writes and the ` +
-            `startup sweep would operate outside the storage root. Replace it with a real directory or configure ` +
-            `a different tempDirectoryName.`
-        )
-      }
-    }
-    // A legacy flat-mode content id could live exactly AT the reserved path as a file; mkdir would
-    // then fail with a low-level filesystem error. Detect it first and give the same actionable
-    // guidance as the other reservation conflicts.
-    if (await components.fs.existPath(tempDir)) {
-      const tempDirStat = await components.fs.stat(tempDir)
-      if (!tempDirStat.isDirectory()) {
-        throw new Error(
-          `Refusing to start: the reserved temp path '${tempDirName}' under the storage root exists as a file — ` +
-            `likely a pre-existing content id. Migrate it out or configure a different tempDirectoryName.`
-        )
-      }
-    }
-    // Created up front so storeStream can stage into it without a per-write mkdir.
-    await components.fs.mkdir(tempDir, { recursive: true })
-  }
-
-  // Staged files are prefixed with a per-boot random id so the startup sweep can tell leftovers
-  // from previous runs (any other prefix) apart from files this instance is writing right now —
-  // a write racing the sweep can therefore never have its live staged file unlinked.
-  const bootId = randomBytes(8).toString('hex')
-  const newTempPath = (): string => path.join(tempDir, `${bootId}-${randomBytes(16).toString('hex')}`)
-
-  // Journal for representation-transition commits: written before the commit rename whenever a
-  // counterpart representation exists, removed once the counterpart is confirmed gone. A crash in
-  // between leaves the intent behind, and the next construction resolves the mixed state in favor
-  // of the representation the intent names (see reconcileIntents). The path is a deterministic
-  // function of the id — at most one intent per id can ever exist, because commits are serialized
-  // per path and construction reconciles before any write — so reconciliation needs no ordering
-  // heuristics. Fresh-id writes — the overwhelmingly common case in content-addressed use — have no
-  // counterpart and never pay for an intent.
-  const intentPathFor = (id: string): string =>
-    path.join(tempDir, `${createHash('sha1').update(id).digest('hex')}.intent`)
-
-  // Existence check for recovery invariants. existPath() tests F_OK|R_OK, so a file left behind by
-  // a failed unlink in an UNREADABLE state (mode/ACL damage, transient permission problem) would
-  // read as absent — letting a must-succeed cleanup be falsely considered complete, and the mixed
-  // state resurface later with no repair signal. Here only ENOENT/ENOTDIR mean absent; any other
-  // error fails the repair/commit path loudly.
-  async function existsForInvariant(target: string): Promise<boolean> {
-    try {
-      await components.fs.stat(target)
-      return true
-    } catch (err: any) {
-      if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') return false
-      throw err
-    }
-  }
-
-  // Ids whose post-rename counterpart cleanup failed in THIS process: the on-disk state is mixed
-  // (new primary + stale counterpart) with the intent preserved, and live reads must not serve it —
-  // non-range reads would prefer the stale counterpart while range reads see the new bytes. Reads
-  // check this set (an O(1) lookup, no syscalls — the hot path is untouched when it is empty) and,
-  // for a quarantined id, repair under the path lock or report the id unavailable. Entries clear on
-  // any successful repair (read-triggered, retried store, delete) and do not survive restarts,
-  // where construction-time reconciliation takes over.
-  const unreconciledIds = new Set<string>()
-
-  // Repair gate for reads of a quarantined id: applies the pending intent under the path lock and
-  // reports whether the id is safe to serve. Never throws — an unrepairable id stays quarantined
-  // and the caller reports no result rather than exposing a known-mixed state.
-  async function ensureReconciled(id: string): Promise<boolean> {
-    if (!unreconciledIds.has(id)) return true
-    const filePath = await getFilePath(id)
-    return withPathLock(filePath, async () => {
-      if (!unreconciledIds.has(id)) return true
-      try {
-        const intentPath = intentPathFor(id)
-        if (await existsForInvariant(intentPath)) {
-          await applyPendingIntent(intentPath)
-        } else {
-          // No journal left: the mixed state was repaired elsewhere (retried store, delete).
-          unreconciledIds.delete(id)
-        }
-        return !unreconciledIds.has(id)
-      } catch {
-        return false
-      }
-    })
-  }
-
-  // After a FAILED commit rename, the pre-rename intent must be PROVABLY gone before the staged
-  // proof may be discarded. Both "the journal survived" and "the journal cannot be proven gone"
-  // (the verification stat itself fails) preserve the proof via the typed error — otherwise a raw
-  // EACCES would escape untyped, the callers' staging cleanup would destroy the staged file, and a
-  // later restart could misapply the surviving pre-rename intent as a committed transition.
-  async function clearIntentOrThrowPreservingProof(
-    intentPath: string,
-    stagedPath: string,
-    id: string,
-    originalError: unknown
-  ): Promise<void> {
-    await noFailUnlink(intentPath)
-    try {
-      if (!(await existsForInvariant(intentPath))) return
-    } catch {
-      // Could not prove the dangerous journal is gone; fall through and preserve the staged proof.
-    }
-    throw new UncommittedIntentSurvivedError(
-      stagedPath,
-      `Failed to commit ${id} AND failed to prove its intent journal was removed; the staged file is preserved ` +
-        `as proof the commit never landed, so a restart repairs this once the filesystem issue is fixed. ` +
-        `Original error: ${originalError instanceof Error ? originalError.message : String(originalError)}`
-    )
-  }
-
-  // Removing an intent journal is semantically must-succeed wherever it is called: a journal that
-  // outlives its purpose is later interpreted as a pending repair instruction. Centralized so the
-  // invariant cannot be accidentally weakened back into a best-effort unlink.
-  async function removeIntentOrThrow(intentPath: string, context: string): Promise<void> {
-    await noFailUnlink(intentPath)
-    if (await existsForInvariant(intentPath)) {
-      throw new Error(`${context}: the intent journal '${intentPath}' could not be removed.`)
-    }
-  }
-
-  async function writeIntent(op: 'raw' | 'gzip', id: string, stagedPath: string): Promise<string> {
-    const intentPath = intentPathFor(id)
-    // The staged BASENAME lets reconciliation prove whether the commit rename landed: renames
-    // consume the staged file, so "staged still present" means the rename provably never happened.
-    // Stored as a basename (not an absolute path) so a root remount cannot poison the journal.
-    const body = JSON.stringify({ op, id, staged: path.basename(stagedPath) })
-    await pipe(Readable.from([Buffer.from(body)]), components.fs.createWriteStream(intentPath))
-    return intentPath
-  }
-
-  // Applies a pending intent, distinguishing the two crash windows by the staged file the intent
-  // names (reconciliation runs before the sweep, so a crashed boot's staged file is still there):
-  // - staged file present  → the rename never happened: discard the staged file and the intent; the
-  //   previous representation(s) stay untouched. A pre-rename intent can therefore NEVER delete the
-  //   previous primary (e.g. a valid gzip alongside its own decompressed raw cache).
-  // - staged gone, primary present → the rename landed: remove the stale counterpart (throwing when
-  //   it cannot be removed — live reads do not consult intents and would keep serving it), then
-  //   discharge the intent.
-  // - neither → nothing can be proven: refuse, manual repair required.
-  // Used by construction-time reconciliation and by commits that find a pending intent for their id
-  // (a failed cleanup earlier in this process), so an unapplied repair instruction is never
-  // overwritten.
-  async function applyPendingIntent(intentPath: string): Promise<void> {
-    const body = await components.fs.readFile(intentPath, 'utf8')
-    let op: string, id: string, staged: string
-    try {
-      ;({ op, id, staged } = JSON.parse(body))
-    } catch {
-      op = id = staged = ''
-    }
-    if (
-      (op !== 'raw' && op !== 'gzip') ||
-      !id ||
-      !STAGED_FILE_NAME.test(staged ?? '') ||
-      // The intent path is a deterministic function of the id: a body whose id does not hash to
-      // this filename is corruption or operator error, and applying it would reconcile the WRONG
-      // id. Treat it as malformed.
-      intentPathFor(id) !== intentPath
-    ) {
-      // A partial/malformed intent means its commit never started (intents are written before
-      // renames): discard it; an orphaned staged file, if any, is handled by the sweep.
-      await removeIntentOrThrow(intentPath, 'Discarding a malformed intent journal failed')
-      return
-    }
-    const stagedPath = path.join(tempDir, staged)
-    if (await existsForInvariant(stagedPath)) {
-      // Prepared but never renamed: the commit did not happen. The staged file is the PROOF of
-      // that, and the intent is the dangerous artifact — remove the journal first (must succeed),
-      // and only then the inert staged garbage. The reverse order could destroy the proof while the
-      // journal survives, letting the next construction reinterpret this pre-rename intent as a
-      // committed transition and delete the valid counterpart.
-      await removeIntentOrThrow(intentPath, `Cannot discard the uncommitted ${op} intent for ${id}`)
-      await noFailUnlink(stagedPath)
-      unreconciledIds.delete(id)
-      logger.info(`Discarded a prepared but uncommitted ${op} transition`, { id })
-      return
-    }
-    const filePath = await getFilePath(id)
-    const gzipPath = filePath + '.gzip'
-    const primaryPath = op === 'raw' ? filePath : gzipPath
-    const counterpartPath = op === 'raw' ? gzipPath : filePath
-    if (!(await existsForInvariant(primaryPath))) {
-      throw new Error(
-        `Cannot reconcile the interrupted ${op} commit for ${id}: neither its staged file nor its committed ` +
-          `representation exists.`
-      )
-    }
-    if (await existsForInvariant(counterpartPath)) {
-      await noFailUnlink(counterpartPath)
-      if (await existsForInvariant(counterpartPath)) {
-        throw new Error(
-          `Cannot repair the interrupted ${op} commit for ${id}: its stale ${
-            op === 'raw' ? 'gzip' : 'raw'
-          } representation could not be removed.`
-        )
-      }
-      logger.info(`Reconciled an interrupted ${op} commit`, { id })
-    }
-    await removeIntentOrThrow(intentPath, `Reconciled ${id} but could not discharge its intent journal`)
-    unreconciledIds.delete(id)
-  }
-
-  // Construction invariant: the storage never runs in a state where the reserved staging namespace
-  // could hide addressable content. With hash prefixes, ids can never resolve into the reserved dir
-  // (containment sends them under a shard), so everything inside is ours by construction. In flat
-  // (disablePrefixHash) mode the root IS the content namespace, so ownership must be proven, and
-  // the marker's mere EXISTENCE is not proof: before the reservation, the marker path itself was a
-  // valid content id, so a legacy deployment could hold an arbitrary file there. Ownership requires
-  // ALL of: the marker exists, its bytes are exactly what this storage writes, and every other
-  // entry matches the staged-name shape this storage generates. Anything else — an unmarked
-  // non-empty directory, a marker with foreign content, an unrecognized sibling, or a failure to
-  // establish ownership — REFUSES TO START instead of warning-and-hiding: pre-existing ids under
-  // the reserved name would otherwise be silently unreachable (or, shape-matching ones, sweepable)
-  // after an upgrade. A byte-exact forgery of the marker alongside exclusively staged-shaped
-  // siblings is indistinguishable from genuine ownership by construction and is treated as opt-in.
-  // This also means the orphan sweep never needs a runtime ownership check.
-  const OWNERSHIP_MARKER = '.owned-by-catalyst-storage'
-  const OWNERSHIP_MARKER_CONTENT = 'reserved by catalyst-storage for atomic write staging\n'
-  if (ATOMIC_MODE && !USE_HASH_PREFIX) {
-    const markerPath = path.join(tempDir, OWNERSHIP_MARKER)
-    const refuseToStart = (reason: string): never => {
-      throw new Error(
-        `Refusing to start: ${reason} In disablePrefixHash mode the reserved temp directory '${tempDirName}' may hold ` +
-          `pre-existing content ids that the reservation would hide from retrieval and enumeration. ` +
-          `Migrate those files out of '${tempDirName}', configure a different tempDirectoryName, or restore the ` +
-          `'${OWNERSHIP_MARKER}' marker (with its original content) if they are staging leftovers from a previous run.`
-      )
-    }
-    if (await components.fs.existPath(markerPath)) {
-      const markerBody = await components.fs.readFile(markerPath, 'utf8')
-      if (markerBody !== OWNERSHIP_MARKER_CONTENT) {
-        refuseToStart(
-          `the ownership marker '${OWNERSHIP_MARKER}' exists but its content is not the one this storage writes, ` +
-            `so it may be a pre-existing content id rather than a marker.`
-        )
-      }
-      const foreign = (await components.fs.readdir(tempDir)).filter(
-        (entry) => entry !== OWNERSHIP_MARKER && !STAGED_FILE_NAME.test(entry) && !INTENT_FILE_NAME.test(entry)
-      )
-      if (foreign.length > 0) {
-        refuseToStart(
-          `the reserved temp directory '${tempDirName}' contains ${foreign.length} file(s) that this storage ` +
-            `did not create.`
-        )
-      }
-    } else {
-      const entries = await components.fs.readdir(tempDir)
-      if (entries.length > 0) {
-        refuseToStart(
-          `the reserved temp directory '${tempDirName}' already contains ${entries.length} file(s) that this ` +
-            `storage cannot prove it owns.`
-        )
-      }
-      await pipe(Readable.from([Buffer.from(OWNERSHIP_MARKER_CONTENT)]), components.fs.createWriteStream(markerPath))
-    }
-  }
-
-  const CACHE_TTL = options?.decompressCacheTTL ?? ONE_HOUR_IN_MS
-  const CACHE_MAX_SIZE = options?.decompressCacheMaxSize ?? FIVE_GB_IN_BYTES
   const CACHE_EVICTION_INTERVAL = options?.decompressCacheEvictionInterval ?? FIVE_MINUTES_IN_MS
   const MAX_DECOMPRESSED_SIZE = options?.decompressMaxFileSize ?? TWO_HUNDRED_FIFTY_SIX_MB_IN_BYTES
 
-  // LRU cache tracker for decompressed gzip files written to disk
-  const decompressCache = new Map<string, { size: number; lastAccess: number }>()
-  let totalCacheSize = 0
-
-  // Concurrency guard: prevents multiple simultaneous decompressions of the same file
-  const inflightDecompressions = new Map<string, Promise<void>>()
-
-  // Serializes commits (rename/write/unlink) on a canonical path so a store, a delete and a
-  // decompression can never interleave their final steps. Only the short commit sections take the
-  // lock — long-running pipes stay outside — and the map entry is removed once its chain drains.
-  const pathLocks = new Map<string, Promise<unknown>>()
-  function withPathLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
-    const prev = pathLocks.get(filePath) ?? Promise.resolve()
-    const run = prev.then(fn, fn)
-    const guard = run.then(
-      () => undefined,
-      () => undefined
-    )
-    pathLocks.set(filePath, guard)
-    void guard.then(() => {
-      if (pathLocks.get(filePath) === guard) pathLocks.delete(filePath)
-    })
-    return run
-  }
-
-  // A decompression inflates whatever gzip existed when it started; if the id is overwritten or
-  // deleted before the decompression commits, its output is stale and must be discarded instead of
-  // clobbering the newer canonical file (or resurrecting a deleted one). The owner registers a token
-  // before opening the gzip; writers/deleters mark it inside their locked commit. Bounded by
-  // in-flight decompressions.
-  const inflightDecompressionTokens = new Map<string, { invalidated: boolean }>()
-  function invalidateInflightDecompression(filePath: string): void {
-    const token = inflightDecompressionTokens.get(filePath)
-    if (token) token.invalidated = true
-  }
-
-  // Commits a staged file onto its canonical primary path and removes the other representation.
-  // The logical object spans two paths (raw and .gzip) but only the rename is atomic, so when a
-  // counterpart exists an intent is journaled FIRST: if the process dies (or the unlink fails)
-  // between the rename and the cleanup, the next construction reconciles the mixed state in favor
-  // of the representation committed here, instead of reads preferring the stale counterpart. Must
-  // be called while holding the path lock.
-  async function commitRepresentation(
-    op: 'raw' | 'gzip',
-    id: string,
-    stagedPath: string,
-    primaryPath: string,
-    counterpartPath: string,
-    rename: (from: string, to: string) => Promise<void>,
-    signal?: AbortSignal
-  ): Promise<void> {
-    try {
-      await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename, signal)
-    } catch (err) {
-      // The commit phase's own cancellation checkpoints throw the caller's abort reason and nothing
-      // else, so identity is the whole test: pass that through untouched (it IS a cancellation, and
-      // marking would tag a caller-owned object with this module's internal symbol). Every other
-      // failure here — pending-intent repair, journal write, rename, counterpart cleanup, quarantine
-      // — cannot be caused by abort teardown (the source is fully consumed before any commit begins
-      // and this backend has no abort hook), so it is a real storage error that cancellation
-      // translation must never mask, whatever shape it happens to have.
-      if (signal?.aborted && err === signal.reason) {
-        throw err
-      }
-      throw markAsNonCancellationError(err)
+  const cache = createDecompressCache(
+    { logger, fsInvariants: { existsForInvariant, noFailUnlink } },
+    {
+      ttl: options?.decompressCacheTTL ?? ONE_HOUR_IN_MS,
+      maxSize: options?.decompressCacheMaxSize ?? FIVE_GB_IN_BYTES
     }
-  }
-
-  async function doCommitRepresentation(
-    op: 'raw' | 'gzip',
-    id: string,
-    stagedPath: string,
-    primaryPath: string,
-    counterpartPath: string,
-    rename: (from: string, to: string) => Promise<void>,
-    signal?: AbortSignal
-  ): Promise<void> {
-    // A pending intent means a previous commit for this id failed its cleanup in this process:
-    // repair first (throws if impossible), so the intent written below always describes a
-    // transition from a consistent state and never overwrites an unapplied repair instruction.
-    if (await existsForInvariant(intentPathFor(id))) {
-      await applyPendingIntent(intentPathFor(id))
-    }
-    // The pre-rename phase awaits repair, existence checks and the journal write: an abort landing
-    // during any of them (with the source long consumed) must still cancel before the irreversible
-    // rename. Here no commit artifact exists yet, so a plain throw suffices; a completed repair
-    // above is idempotent state that needs no undoing.
-    signal?.throwIfAborted()
-    const hadCounterpart = await existsForInvariant(counterpartPath)
-    const intentPath = hadCounterpart ? await writeIntent(op, id, stagedPath) : undefined
-    if (intentPath && signal?.aborted) {
-      // Cancelled after the intent was journaled but before the rename: the commit never happened,
-      // so the journal must not survive (a later repair would apply it as a completed transition).
-      // Clearing it is must-succeed — if it cannot be cleared, the staged file is preserved as the
-      // proof the rename never landed, exactly like a failed rename.
-      await clearIntentOrThrowPreservingProof(intentPath, stagedPath, id, signal.reason)
-    }
-    // Unconditional last checkpoint before the irreversible rename: without it, an abort landing
-    // during the awaited counterpart check on a fresh id (no counterpart → no intent → the block
-    // above skipped) would proceed to commit. No journal exists past this line unless it was just
-    // cleared, so a plain throw is safe.
-    signal?.throwIfAborted()
-    try {
-      await rename(stagedPath, primaryPath)
-    } catch (err) {
-      // The commit did not happen, so the intent must not survive it: a later repair would treat
-      // the failed commit as successful and remove the counterpart — e.g. delete a valid gzip
-      // primary in favor of its own decompressed raw cache.
-      if (intentPath) {
-        // A surviving (or unprovably-removed) intent could later be applied as if the commit
-        // succeeded. The staged file is the proof it did not — the typed error tells callers to
-        // preserve it, which also makes this state self-healing: the next construction sees the
-        // staged file, classifies the intent as pre-rename and discards both, previous
-        // representations untouched.
-        await clearIntentOrThrowPreservingProof(intentPath, stagedPath, id, err)
-      }
-      throw err
-    }
-    if (hadCounterpart) {
-      await noFailUnlink(counterpartPath)
-      let counterpartGone: boolean
-      try {
-        counterpartGone = !(await existsForInvariant(counterpartPath))
-      } catch (verifyErr) {
-        // Possibly mixed and unprovable: quarantine so reads repair-or-refuse instead of serving it.
-        unreconciledIds.add(id)
-        throw verifyErr
-      }
-      if (!counterpartGone) {
-        // The new version is committed, but the stale counterpart could not be removed. The
-        // on-disk state is MIXED: without a guard, non-range reads would keep preferring the stale
-        // counterpart while range reads see the new bytes — two versions of one id from the same
-        // process. Quarantine the id (reads repair-or-refuse, see ensureReconciled) and fail the
-        // store loudly; the intent survives, so a retried store, a read-triggered repair or the
-        // next construction finishes the cleanup.
-        unreconciledIds.add(id)
-        throw new Error(
-          `Stored ${id} but failed to remove its previous ${op === 'raw' ? 'gzip' : 'raw'} representation; ` +
-            `the id is quarantined from reads until a retry, read-triggered repair or restart completes the cleanup.`
-        )
-      }
-      if (intentPath) {
-        await removeIntentOrThrow(intentPath, `Committed ${id} but could not discharge its intent journal`)
-      }
-      unreconciledIds.delete(id)
-    }
-  }
-
-  // Shared no-rename (legacy) direct write. MUST be called while holding the path lock. Writes the
-  // raw in place and enforces the same successful-write invariant as the atomic path: never resolve
-  // while the preferred gzip counterpart survives. There is no journal in this mode, so a surviving
-  // gzip rolls the in-place store back through the catch — the previous gzip version stays cleanly
-  // intact (the raw overwritten by the pipe can only have been that gzip's own re-derivable cache).
-  async function writeRawInPlaceLocked(
-    id: string,
-    filePath: string,
-    stream: Readable,
-    signal?: AbortSignal
-  ): Promise<void> {
-    // Cancellation is only honored BEFORE the destructive in-place write begins — outside the
-    // rollback path below, since nothing has been touched yet. Once the pipe has replaced the
-    // canonical raw, the previous version is already gone (in-place semantics): an abort observed
-    // after that point treats the store as completed, because "rolling back" would unlink the only
-    // committed object rather than restore anything. A mid-write abort destroys the source, and the
-    // resulting pipe failure follows this mode's usual non-atomic handling (the partial overwrite
-    // is removed; the previous raw version cannot be preserved without rename support).
-    signal?.throwIfAborted()
-    try {
-      await pipe(stream, components.fs.createWriteStream(filePath))
-      await noFailUnlink(filePath + '.gzip')
-      if (await existsForInvariant(filePath + '.gzip')) {
-        // A post-write invariant failure, never abort-caused: keep it visible past cancellation.
-        throw markAsNonCancellationError(
-          new Error(
-            `Failed to remove the previous gzip representation of ${id}; the in-place store was rolled back ` +
-              `and reads keep serving the previous version.`
-          )
-        )
-      }
-      forgetCacheEntry(filePath)
-      invalidateInflightDecompression(filePath)
-    } catch (err) {
-      // Clean up the partial output while still holding the lock: doing it after release could
-      // delete a queued writer's freshly committed content for the same id.
-      await noFailUnlink(filePath)
-      throw err
-    }
-  }
-
-  // Drops the cache-tracking entry WITHOUT unlinking the file. Used when the canonical path stops
-  // being a derived cache and becomes primary content (a store landed there): a stale entry would
-  // let TTL/size eviction delete the only copy of the new content.
-  function forgetCacheEntry(filePath: string): void {
-    const entry = decompressCache.get(filePath)
-    if (entry) {
-      totalCacheSize -= entry.size
-      decompressCache.delete(filePath)
-    }
-  }
-
-  // Returns the CURRENT in-flight eviction when one is already running, instead of a resolved
-  // no-op: the interval callback assigns this to the tracked tick, so a tick firing during a slow
-  // eviction must hand back the real promise — otherwise stop() would await the no-op and could
-  // resolve while the actual eviction is still unlinking files.
-  let inflightEviction: Promise<void> | undefined
-  function evictCache(): Promise<void> {
-    if (inflightEviction) return inflightEviction
-    inflightEviction = runEviction()
-      .catch((error) => logger.warn(`Cache eviction failed: ${error}`))
-      .finally(() => {
-        inflightEviction = undefined
-      })
-    return inflightEviction
-  }
-
-  // Unlinks an evicted cache file under the path lock, re-checking the entry is still current: a
-  // store may have promoted the path to primary content (forgetting the entry) between the eviction
-  // scan and this delete — unlinking then would destroy the only copy of the new content.
-  async function evictCacheEntry(filePath: string, entry: { size: number; lastAccess: number }): Promise<void> {
-    await withPathLock(filePath, async () => {
-      if (decompressCache.get(filePath) !== entry) return
-      await noFailUnlink(filePath)
-      // Keep the tracking when the file survives the unlink, so the next eviction tick retries it
-      // instead of leaving an untracked (unaccounted, never-retried) cache file on disk.
-      if (await existsForInvariant(filePath)) return
-      totalCacheSize -= entry.size
-      decompressCache.delete(filePath)
-    })
-  }
-
-  async function runEviction() {
-    const now = Date.now()
-
-    // TTL eviction
-    for (const [filePath, entry] of decompressCache) {
-      if (now - entry.lastAccess > CACHE_TTL) {
-        await evictCacheEntry(filePath, entry)
-      }
-    }
-
-    // Size eviction (LRU)
-    if (totalCacheSize > CACHE_MAX_SIZE) {
-      const sorted = [...decompressCache.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess)
-      for (const [filePath, entry] of sorted) {
-        if (totalCacheSize <= CACHE_MAX_SIZE) break
-        await evictCacheEntry(filePath, entry)
-      }
-    }
-  }
-
-  let evictionTimer: ReturnType<typeof setInterval> | undefined
-  // Tracks the in-flight eviction tick so `stop()` can await one that is already running.
-  let evictionTick: Promise<void> = Promise.resolve()
-  // Tracks the detached startup temp-file sweep so `stop()` can await it (rather than leaving a
-  // promise dangling past shutdown). Repeated start() calls CHAIN onto it instead of replacing it.
-  let tempFileSweep: Promise<void> = Promise.resolve()
+  )
+  const { withPathLock } = cache
 
   // Directories this instance has already created or observed. `getFilePath` runs on EVERY
   // operation — including every read — and its directory check was one syscall per call (~30% of an
@@ -725,6 +175,30 @@ export async function createFolderBasedFileSystemContentStorage(
   function forgetDirectory(dirname: string): void {
     knownDirectories.delete(dirname)
   }
+
+  await components.fs.mkdir(root, { recursive: true })
+
+  // Prepares (and refuses to start over an unsafe) staging area, so it must run after the root
+  // exists and after all configuration has been validated.
+  const journal = await createIntentJournal(
+    {
+      fs: components.fs,
+      logger,
+      fsInvariants: { existsForInvariant, noFailUnlink },
+      withPathLock,
+      // Resolved lazily: reconciliation runs after construction, so getFilePath's state is ready by
+      // then (it is declared above this call for that reason).
+      resolveFilePath: (id: string) => getFilePath(id)
+    },
+    { tempDir, tempDirName, atomic: ATOMIC_MODE, useHashPrefix: USE_HASH_PREFIX }
+  )
+
+  let evictionTimer: ReturnType<typeof setInterval> | undefined
+  // Tracks the in-flight eviction tick so `stop()` can await one that is already running.
+  let evictionTick: Promise<void> = Promise.resolve()
+  // Tracks the detached startup temp-file sweep so `stop()` can await it (rather than leaving a
+  // promise dangling past shutdown). Repeated start() calls CHAIN onto it instead of replacing it.
+  let tempFileSweep: Promise<void> = Promise.resolve()
 
   /**
    * Read-path existence probe: ONE stat instead of `existPath` followed by `stat`, since a stat
@@ -808,12 +282,44 @@ export async function createFolderBasedFileSystemContentStorage(
     return undefined
   }
 
-  const noFailUnlink = async (path: string): Promise<boolean> => {
+  // Shared no-rename (legacy) direct write. MUST be called while holding the path lock. Writes the
+  // raw in place and enforces the same successful-write invariant as the atomic path: never resolve
+  // while the preferred gzip counterpart survives. There is no journal in this mode, so a surviving
+  // gzip rolls the in-place store back through the catch — the previous gzip version stays cleanly
+  // intact (the raw overwritten by the pipe can only have been that gzip's own re-derivable cache).
+  async function writeRawInPlaceLocked(
+    id: string,
+    filePath: string,
+    stream: Readable,
+    signal?: AbortSignal
+  ): Promise<void> {
+    // Cancellation is only honored BEFORE the destructive in-place write begins — outside the
+    // rollback path below, since nothing has been touched yet. Once the pipe has replaced the
+    // canonical raw, the previous version is already gone (in-place semantics): an abort observed
+    // after that point treats the store as completed, because "rolling back" would unlink the only
+    // committed object rather than restore anything. A mid-write abort destroys the source, and the
+    // resulting pipe failure follows this mode's usual non-atomic handling (the partial overwrite
+    // is removed; the previous raw version cannot be preserved without rename support).
+    signal?.throwIfAborted()
     try {
-      await components.fs.unlink(path)
-      return true
-    } catch (error) {
-      return false
+      await pipe(stream, components.fs.createWriteStream(filePath))
+      await noFailUnlink(filePath + '.gzip')
+      if (await existsForInvariant(filePath + '.gzip')) {
+        // A post-write invariant failure, never abort-caused: keep it visible past cancellation.
+        throw markAsNonCancellationError(
+          new Error(
+            `Failed to remove the previous gzip representation of ${id}; the in-place store was rolled back ` +
+              `and reads keep serving the previous version.`
+          )
+        )
+      }
+      cache.forget(filePath)
+      cache.invalidateInflight(filePath)
+    } catch (err) {
+      // Clean up the partial output while still holding the lock: doing it after release could
+      // delete a queued writer's freshly committed content for the same id.
+      await noFailUnlink(filePath)
+      throw err
     }
   }
 
@@ -835,7 +341,7 @@ export async function createFolderBasedFileSystemContentStorage(
     // one. Temp files live outside the content namespace, so they cannot collide with an addressable
     // id. (Data is not fsync'd before the rename, so a power loss can still lose it — content is
     // content-addressed and simply re-downloaded, so durability past process death isn't needed.)
-    const tempPath = newTempPath()
+    const tempPath = journal.newTempPath()
     try {
       await pipe(stream, components.fs.createWriteStream(tempPath))
       // An abort observed once the source is consumed must still cancel the store before the
@@ -851,13 +357,13 @@ export async function createFolderBasedFileSystemContentStorage(
           // The raw and its .gzip are one versioned object: a gzip left from a previous version
           // would be preferred by retrieve() and serve stale bytes over the content just stored
           // (intent-journaled so even a crash mid-cleanup cannot leave the stale gzip preferred).
-          await commitRepresentation('raw', id, tempPath, filePath, filePath + '.gzip', rename, signal)
+          await journal.commitRepresentation('raw', id, tempPath, filePath, filePath + '.gzip', rename, signal)
         } finally {
           // Run the bookkeeping even when the commit throws (a failed counterpart cleanup reports
           // failure AFTER the rename landed): drop any stale decompress-cache tracking so eviction
           // can never delete the new content, and tell an in-flight decompression it is outdated.
-          forgetCacheEntry(filePath)
-          invalidateInflightDecompression(filePath)
+          cache.forget(filePath)
+          cache.invalidateInflight(filePath)
         }
       })
     } catch (err) {
@@ -877,28 +383,6 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  async function removeCacheEntry(filePath: string): Promise<boolean> {
-    const entry = decompressCache.get(filePath)
-    if (!entry) return false
-    await noFailUnlink(filePath)
-    // Verify before dropping the tracking: reporting the cached raw as handled while it survives
-    // would let delete() remove the gzip and resolve — resurrecting the untracked cache file as
-    // readable primary content after a "successful" delete.
-    if (await existsForInvariant(filePath)) {
-      throw new Error(`Failed to remove the cached decompressed content at ${filePath}`)
-    }
-    totalCacheSize -= entry.size
-    decompressCache.delete(filePath)
-    return true
-  }
-
-  function touchCacheEntry(filePath: string) {
-    const entry = decompressCache.get(filePath)
-    if (entry) {
-      entry.lastAccess = Date.now()
-    }
-  }
-
   // Concurrent-read contract: reads are deliberately NOT serialized against writes (locking the hot
   // read path would be far too costly). Every read observes some COMPLETE committed version of the
   // id — commits are atomic renames and a version's raw/gzip transition happens under the path
@@ -909,10 +393,10 @@ export async function createFolderBasedFileSystemContentStorage(
   // can unlink the observed file, making asStream() fail (typically ENOENT) — callers should treat
   // that as a retryable miss, exactly like retrieve() having returned undefined. Ids quarantined by
   // a failed post-rename cleanup are repaired before serving or reported as absent — a read never
-  // exposes a known-mixed state (see unreconciledIds).
+  // exposes a known-mixed state (see the intent journal's quarantine).
   const retrieve = async (id: string, range?: { start: number; end: number }): Promise<ContentItem | undefined> => {
     if (range) validateRange(range)
-    if (unreconciledIds.has(id) && !(await ensureReconciled(id))) {
+    if (journal.isQuarantined(id) && !(await journal.ensureReconciled(id))) {
       logger.warn(`Refusing to serve a quarantined mixed-state id`, { id })
       return undefined
     }
@@ -923,7 +407,7 @@ export async function createFolderBasedFileSystemContentStorage(
         contentItem = await retrieveWithEncoding(id, null, range)
         if (contentItem && range) {
           // Update last access if this file is in the cache
-          touchCacheEntry(await getFilePath(id))
+          cache.touch(await getFilePath(id))
         }
       }
 
@@ -936,105 +420,78 @@ export async function createFolderBasedFileSystemContentStorage(
       for (let attempt = 0; attempt < 2 && !contentItem && range; attempt++) {
         const uncompressedPath = await getFilePath(id)
 
-        // Deduplicate concurrent decompressions of the same file. The promise is created and
-        // registered synchronously — there is no `await` between the `get` and the `set` — so
-        // simultaneous callers share a single decompression. Otherwise both would pass the
-        // "not in flight" check, write the same cache file concurrently (corrupting it) and
-        // double-count its size against totalCacheSize.
-        let decompressPromise = inflightDecompressions.get(uncompressedPath)
-        const isOwner = !decompressPromise
-        if (!decompressPromise) {
-          decompressPromise = (async () => {
-            // Register the invalidation token BEFORE opening the gzip: any store/delete committing
-            // after this point marks it, so stale output is discarded; one committing before it means
-            // the gzip opened below is already the newest version.
-            const token = { invalidated: false }
-            inflightDecompressionTokens.set(uncompressedPath, token)
+        // Deduplicated across concurrent callers of the same path, and handed the invalidation token
+        // that says whether the gzip this inflation started from is still the current version.
+        await cache.deduplicateInflation(uncompressedPath, async (token) => {
+          const gzipItem = await retrieveWithEncoding(id, 'gzip')
+          if (!gzipItem) {
+            return
+          }
+          const { rename } = components.fs
+          if (rename) {
+            // Stage the inflation in the temp dir so a process killed mid-decompress can never
+            // leave a partial file at the canonical uncompressed path — a later range request
+            // would silently serve its truncated bytes as valid content.
+            const writePath = journal.newTempPath()
             try {
-              const gzipItem = await retrieveWithEncoding(id, 'gzip')
-              if (!gzipItem) {
-                return
-              }
-              const { rename } = components.fs
-              if (rename) {
-                // Stage the inflation in the temp dir so a process killed mid-decompress can never
-                // leave a partial file at the canonical uncompressed path — a later range request
-                // would silently serve its truncated bytes as valid content.
-                const writePath = newTempPath()
-                try {
-                  // Cap how much the gzip may inflate to so a decompression bomb cannot write an
-                  // unbounded file to disk. The gzip trailer's declared size is attacker-
-                  // controllable, so the limit is enforced on the actual inflated bytes.
-                  await pipe(
-                    await gzipItem.asStream(),
-                    createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
-                    components.fs.createWriteStream(writePath)
-                  )
-                  // Commit under the path lock so this rename can never interleave with a store or
-                  // delete on the same canonical path; discard when the source gzip was replaced or
-                  // the id deleted while inflating.
-                  const committed = await withPathLock(uncompressedPath, async () => {
-                    if (token.invalidated) return false
-                    await rename(writePath, uncompressedPath)
-                    const stat = await components.fs.stat(uncompressedPath)
-                    decompressCache.set(uncompressedPath, { size: stat.size, lastAccess: Date.now() })
-                    totalCacheSize += stat.size
-                    return true
-                  })
-                  if (!committed) {
-                    await noFailUnlink(writePath)
-                  }
-                } catch (err) {
-                  // Remove the partial staged file; the canonical path was never touched.
-                  await noFailUnlink(writePath)
-                  // An invalidated token means the id was overwritten/deleted while inflating —
-                  // the failure belongs to the replaced gzip, not to the caller's request.
-                  // Resolving lets the retry loop observe the new representation instead of the
-                  // error bubbling into a spurious undefined for a valid id.
-                  if (token.invalidated) return
-                  throw err
-                }
-                return
-              }
-
-              // In-place (no rename) legacy path: there is no staging, so the ENTIRE inflate/
-              // register sequence runs under the path lock and honors the invalidation token — a
-              // concurrent store/delete completing first must not be overwritten by a stale
-              // decompression, and the cleanup of a failed inflation must not race a newer writer.
-              await withPathLock(uncompressedPath, async () => {
-                if (token.invalidated) return
-                try {
-                  await pipe(
-                    await gzipItem.asStream(),
-                    createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
-                    components.fs.createWriteStream(uncompressedPath)
-                  )
-                } catch (err) {
-                  // Under the lock the partial file is provably ours to remove.
-                  await noFailUnlink(uncompressedPath)
-                  // Defensive symmetry with the staged branch: writers take this same lock, so the
-                  // token cannot flip mid-section today.
-                  if (token.invalidated) return
-                  throw err
-                }
+              // Cap how much the gzip may inflate to so a decompression bomb cannot write an
+              // unbounded file to disk. The gzip trailer's declared size is attacker-
+              // controllable, so the limit is enforced on the actual inflated bytes.
+              await pipe(
+                await gzipItem.asStream(),
+                createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
+                components.fs.createWriteStream(writePath)
+              )
+              // Commit under the path lock so this rename can never interleave with a store or
+              // delete on the same canonical path; discard when the source gzip was replaced or
+              // the id deleted while inflating.
+              const committed = await withPathLock(uncompressedPath, async () => {
+                if (token.invalidated) return false
+                await rename(writePath, uncompressedPath)
                 const stat = await components.fs.stat(uncompressedPath)
-                decompressCache.set(uncompressedPath, { size: stat.size, lastAccess: Date.now() })
-                totalCacheSize += stat.size
+                cache.record(uncompressedPath, stat.size)
+                return true
               })
-            } finally {
-              if (inflightDecompressionTokens.get(uncompressedPath) === token) {
-                inflightDecompressionTokens.delete(uncompressedPath)
+              if (!committed) {
+                await noFailUnlink(writePath)
               }
+            } catch (err) {
+              // Remove the partial staged file; the canonical path was never touched.
+              await noFailUnlink(writePath)
+              // An invalidated token means the id was overwritten/deleted while inflating —
+              // the failure belongs to the replaced gzip, not to the caller's request.
+              // Resolving lets the retry loop observe the new representation instead of the
+              // error bubbling into a spurious undefined for a valid id.
+              if (token.invalidated) return
+              throw err
             }
-          })()
-          inflightDecompressions.set(uncompressedPath, decompressPromise)
-        }
+            return
+          }
 
-        try {
-          await decompressPromise
-        } finally {
-          if (isOwner) inflightDecompressions.delete(uncompressedPath)
-        }
+          // In-place (no rename) legacy path: there is no staging, so the ENTIRE inflate/
+          // register sequence runs under the path lock and honors the invalidation token — a
+          // concurrent store/delete completing first must not be overwritten by a stale
+          // decompression, and the cleanup of a failed inflation must not race a newer writer.
+          await withPathLock(uncompressedPath, async () => {
+            if (token.invalidated) return
+            try {
+              await pipe(
+                await gzipItem.asStream(),
+                createSizeLimitTransform(MAX_DECOMPRESSED_SIZE),
+                components.fs.createWriteStream(uncompressedPath)
+              )
+            } catch (err) {
+              // Under the lock the partial file is provably ours to remove.
+              await noFailUnlink(uncompressedPath)
+              // Defensive symmetry with the staged branch: writers take this same lock, so the
+              // token cannot flip mid-section today.
+              if (token.invalidated) return
+              throw err
+            }
+            const stat = await components.fs.stat(uncompressedPath)
+            cache.record(uncompressedPath, stat.size)
+          })
+        })
 
         // Serve range from the cached uncompressed file (undefined when the gzip didn't exist or
         // the decompression was discarded; the loop then retries once)
@@ -1050,7 +507,7 @@ export async function createFolderBasedFileSystemContentStorage(
   }
 
   async function exist(id: string): Promise<boolean> {
-    if (unreconciledIds.has(id) && !(await ensureReconciled(id))) return false
+    if (journal.isQuarantined(id) && !(await journal.ensureReconciled(id))) return false
     const filePath = await getFilePath(id)
     return (await components.fs.existPath(filePath + '.gzip')) || (await components.fs.existPath(filePath))
   }
@@ -1095,7 +552,7 @@ export async function createFolderBasedFileSystemContentStorage(
   }
 
   async function fileInfo(id: string): Promise<FileInfo | undefined> {
-    if (unreconciledIds.has(id) && !(await ensureReconciled(id))) return undefined
+    if (journal.isQuarantined(id) && !(await journal.ensureReconciled(id))) return undefined
     const possibleEncondings = ['gzip', null]
     const baseFilePath = await getFilePath(id)
 
@@ -1121,62 +578,6 @@ export async function createFolderBasedFileSystemContentStorage(
     }
 
     return undefined
-  }
-
-  // Removes temp files left behind by writes interrupted in a previous run. Staged filenames carry
-  // this boot's random prefix, so a staged-shape file with a different prefix is by construction a
-  // leftover of an earlier process — a write racing this sweep stages under the current bootId and
-  // is never touched. Best-effort: a missing dir or a failed unlink is ignored.
-  const sweepOrphanedTempFiles = async (): Promise<number> => {
-    // No staging happens without atomic-write support, so there is nothing of ours to sweep — and
-    // the directory (if it exists at all) is not ours to touch.
-    if (!ATOMIC_MODE) return 0
-    // Ownership of the reserved dir is a construction invariant (see the OWNERSHIP_MARKER logic in
-    // the factory): if this storage is running, everything staged-shaped in there is ours.
-    let entries: string[]
-    try {
-      entries = await components.fs.readdir(tempDir)
-    } catch {
-      return 0
-    }
-    let removed = 0
-    for (const entry of entries) {
-      if (!STAGED_FILE_NAME.test(entry) || entry.startsWith(`${bootId}-`)) continue
-      if (await noFailUnlink(path.join(tempDir, entry))) removed++
-    }
-    return removed
-  }
-
-  // Resolves mixed raw/gzip states left by a crash between a commit rename and its counterpart
-  // cleanup. Each surviving intent names the representation that was being committed for an id;
-  // when both representations exist, the counterpart is removed so reads can never prefer the stale
-  // one. Only the NEWEST intent per id is applied (a crash can leave several from re-attempts). An
-  // intent whose id is in a consistent state is simply discharged. Runs at construction, before any
-  // operation can observe the storage.
-  async function reconcileIntents(): Promise<void> {
-    // No intents are ever written without atomic-write support.
-    if (!ATOMIC_MODE) return
-    let entries: string[]
-    try {
-      entries = await components.fs.readdir(tempDir)
-    } catch {
-      return
-    }
-    // Intent paths are a deterministic function of the id, so there is at most one per id and no
-    // ordering to resolve. A repair that cannot be completed FAILS CONSTRUCTION: live reads do not
-    // consult intents, so a usable instance over an unreconciled mixed state would keep serving the
-    // stale representation for its whole lifetime.
-    for (const name of entries.filter((entry) => INTENT_FILE_NAME.test(entry)).sort()) {
-      try {
-        await applyPendingIntent(path.join(tempDir, name))
-      } catch (err: any) {
-        throw new Error(
-          `Refusing to start: ${err instanceof Error ? err.message : String(err)} ` +
-            `The intent journal '${name}' under '${tempDirName}' was kept; fix the underlying filesystem issue ` +
-            `(permissions, immutability) and restart.`
-        )
-      }
-    }
   }
 
   const doStoreStreamAndCompress = async (id: string, stream: Readable, signal?: AbortSignal): Promise<void> => {
@@ -1238,8 +639,8 @@ export async function createFolderBasedFileSystemContentStorage(
     // supersede or fail it — and the id transitions in ONE locked commit to either the gzip-only
     // or the raw-only representation of the new version. Until that commit the previous version
     // stays fully intact; a process killed at any point leaves only sweepable staged files.
-    const stagedRawPath = newTempPath()
-    const stagedGzipPath = newTempPath()
+    const stagedRawPath = journal.newTempPath()
+    const stagedGzipPath = journal.newTempPath()
     // Set when a failed rename could not clear its intent: that exact staged path is the proof
     // the commit never landed and must survive the staging cleanup below.
     let preservedStagedPath: string | undefined
@@ -1277,14 +678,14 @@ export async function createFolderBasedFileSystemContentStorage(
           // Intent-journaled: a crash between the commit rename and the counterpart cleanup is
           // reconciled at next construction, never leaving mixed versions for reads to prefer.
           if (compressed) {
-            await commitRepresentation('gzip', id, stagedGzipPath, filePath + '.gzip', filePath, rename, signal)
+            await journal.commitRepresentation('gzip', id, stagedGzipPath, filePath + '.gzip', filePath, rename, signal)
           } else {
-            await commitRepresentation('raw', id, stagedRawPath, filePath, filePath + '.gzip', rename, signal)
+            await journal.commitRepresentation('raw', id, stagedRawPath, filePath, filePath + '.gzip', rename, signal)
           }
         } finally {
           // Run even when the commit throws post-rename (failed counterpart cleanup).
-          forgetCacheEntry(filePath)
-          invalidateInflightDecompression(filePath)
+          cache.forget(filePath)
+          cache.invalidateInflight(filePath)
         }
       })
     } catch (err) {
@@ -1305,7 +706,7 @@ export async function createFolderBasedFileSystemContentStorage(
     }
   }
 
-  await reconcileIntents()
+  await journal.reconcile()
 
   return {
     async start(_startOptions: any) {
@@ -1314,9 +715,9 @@ export async function createFolderBasedFileSystemContentStorage(
         clearInterval(evictionTimer)
       }
       // Track the in-flight eviction tick so stop() can await one that is already running; a tick
-      // firing during a slow eviction receives that same in-flight promise from evictCache().
+      // firing during a slow eviction receives that same in-flight promise from cache.evict().
       evictionTimer = setInterval(() => {
-        evictionTick = evictCache()
+        evictionTick = cache.evict()
       }, CACHE_EVICTION_INTERVAL)
       evictionTimer.unref()
       // Detached best-effort cleanup of temp files orphaned by an interrupted write in a prior run.
@@ -1324,7 +725,7 @@ export async function createFolderBasedFileSystemContentStorage(
       // Chained onto any previous sweep so a repeated start() cannot replace a still-running sweep
       // with a new promise (the older one would dangle past stop()) nor run two sweeps concurrently.
       tempFileSweep = tempFileSweep
-        .then(() => sweepOrphanedTempFiles())
+        .then(() => journal.sweepOrphanedTempFiles())
         .then((removed) => {
           if (removed > 0) logger.info(`Removed ${removed} orphaned temp file(s) at startup`)
         })
@@ -1337,11 +738,9 @@ export async function createFolderBasedFileSystemContentStorage(
       }
       // Wait for the startup temp-file sweep, an in-flight eviction tick and any inflight
       // decompressions before cleaning up
-      await Promise.allSettled([tempFileSweep, evictionTick, ...inflightDecompressions.values()])
+      await Promise.allSettled([tempFileSweep, evictionTick, ...cache.inflight()])
       // Evict all cached files on shutdown to prevent disk leaks across restarts
-      for (const [filePath, entry] of decompressCache) {
-        await evictCacheEntry(filePath, entry)
-      }
+      await cache.evictAll()
     },
     storeStream: (id: string, stream: Readable, signal?: AbortSignal): Promise<void> =>
       runStoreWithSignal(stream, signal, () => doStoreStream(id, stream, signal)),
@@ -1360,15 +759,12 @@ export async function createFolderBasedFileSystemContentStorage(
           // the next construction even though this delete was intentional. Repair first (throws if
           // impossible), which discharges the journal; a crash mid-delete afterwards leaves at
           // worst a partial delete with NO journal, which construction accepts.
-          const pendingIntentPath = intentPathFor(id)
-          if (ATOMIC_MODE && (await existsForInvariant(pendingIntentPath))) {
-            await applyPendingIntent(pendingIntentPath)
-          }
+          await journal.repairPendingIntent(id)
           // Every removal below is verified: a delete that resolves while ANY representation
           // survives (cached raw, primary raw, or gzip) would leave the id readable after a
           // "successful" delete. Failures abort before touching the next representation, so a
           // failed delete always leaves a complete, readable version behind and rejects loudly.
-          const wasCached = await removeCacheEntry(filePath)
+          const wasCached = await cache.remove(filePath)
           if (!wasCached) {
             await noFailUnlink(filePath)
             if (await existsForInvariant(filePath)) {
@@ -1379,11 +775,9 @@ export async function createFolderBasedFileSystemContentStorage(
           if (await existsForInvariant(filePath + '.gzip')) {
             throw new Error(`Failed to delete ${id}: its gzip representation could not be removed`)
           }
-          if (ATOMIC_MODE) {
-            // Defensive: applyPendingIntent already discharged any journal; verify none remains.
-            await removeIntentOrThrow(pendingIntentPath, `Deleted ${id} but could not remove its intent journal`)
-          }
-          invalidateInflightDecompression(filePath)
+          // Defensive: repairPendingIntent already discharged any journal; verify none remains.
+          await journal.assertNoIntent(id, `Deleted ${id} but could not remove its intent journal`)
+          cache.invalidateInflight(filePath)
         })
       }
     },

--- a/src/folder-based/decompress-cache.ts
+++ b/src/folder-based/decompress-cache.ts
@@ -1,0 +1,224 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { FsInvariants } from './fs-invariants'
+
+/**
+ * Marks whether the decompression that owns it is still relevant. A decompression inflates whatever
+ * gzip existed when it started; if the id is overwritten or deleted before the decompression
+ * commits, its output is stale and must be discarded instead of clobbering the newer canonical file
+ * (or resurrecting a deleted one).
+ */
+export type InvalidationToken = { invalidated: boolean }
+
+/**
+ * Tracking for the decompressed copies this storage writes to disk when serving a range request for
+ * gzip-only content, plus the concurrency control that keeps those writes from racing each other or
+ * the canonical paths they land on.
+ *
+ * The cache and the locking live together because they are one concern: an entry is only ever
+ * created, promoted or evicted while holding the lock for its path, which is what makes "is this
+ * file a derived cache or primary content?" a decidable question at every point.
+ */
+export type DecompressCache = {
+  /**
+   * Serializes commits (rename/write/unlink) on a canonical path so a store, a delete and a
+   * decompression can never interleave their final steps. Only the short commit sections take the
+   * lock — long-running pipes stay outside — and the map entry is removed once its chain drains.
+   */
+  withPathLock<T>(filePath: string, fn: () => Promise<T>): Promise<T>
+  /**
+   * Runs `inflate` at most once per path across concurrent callers, and gives it the invalidation
+   * token for that path. The in-flight promise is registered synchronously — no `await` between the
+   * lookup and the store — so simultaneous callers share a single decompression; otherwise both
+   * would pass the "not in flight" check, write the same cache file concurrently (corrupting it) and
+   * double-count its size against the cache total.
+   *
+   * The token is registered BEFORE `inflate` runs: any store/delete committing after that point
+   * marks it, so stale output is discarded, while one committing before it means the gzip the
+   * inflation opens is already the newest version.
+   */
+  deduplicateInflation(filePath: string, inflate: (token: InvalidationToken) => Promise<void>): Promise<void>
+  /** Marks an in-flight decompression for this path stale. Called by writers inside their locked commit. */
+  invalidateInflight(filePath: string): void
+  /** Every in-flight decompression, so shutdown can await them. */
+  inflight(): Iterable<Promise<void>>
+  /** Starts tracking a freshly committed decompressed file. Must be called under the path lock. */
+  record(filePath: string, size: number): void
+  /**
+   * Drops the tracking entry WITHOUT unlinking the file. Used when the canonical path stops being a
+   * derived cache and becomes primary content (a store landed there): a stale entry would let
+   * TTL/size eviction delete the only copy of the new content.
+   */
+  forget(filePath: string): void
+  /**
+   * Removes a tracked cache file and its entry, reporting whether the path was cached at all.
+   * Throws when the file survives: reporting the cached raw as handled while it survives would let
+   * `delete()` remove the gzip and resolve — resurrecting the untracked cache file as readable
+   * primary content after a "successful" delete.
+   */
+  remove(filePath: string): Promise<boolean>
+  /** Refreshes the last-access time used by TTL and LRU eviction. */
+  touch(filePath: string): void
+  /** Runs one eviction pass (TTL, then LRU down to the size budget), deduplicated while in flight. */
+  evict(): Promise<void>
+  /** Evicts every tracked file, to prevent disk leaks across restarts. */
+  evictAll(): Promise<void>
+}
+
+export type DecompressCacheOptions = {
+  /** TTL in milliseconds after which an untouched cached file is evicted. */
+  ttl: number
+  /** Total size budget in bytes; the least recently used entries are evicted past it. */
+  maxSize: number
+}
+
+export function createDecompressCache(
+  components: { logger: ILoggerComponent.ILogger; fsInvariants: FsInvariants },
+  options: DecompressCacheOptions
+): DecompressCache {
+  const { logger } = components
+  const { existsForInvariant, noFailUnlink } = components.fsInvariants
+
+  // LRU cache tracker for decompressed gzip files written to disk
+  const entries = new Map<string, { size: number; lastAccess: number }>()
+  let totalCacheSize = 0
+
+  // Concurrency guard: prevents multiple simultaneous decompressions of the same file
+  const inflightDecompressions = new Map<string, Promise<void>>()
+
+  // Bounded by in-flight decompressions.
+  const inflightTokens = new Map<string, InvalidationToken>()
+
+  const pathLocks = new Map<string, Promise<unknown>>()
+  function withPathLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+    const prev = pathLocks.get(filePath) ?? Promise.resolve()
+    const run = prev.then(fn, fn)
+    const guard = run.then(
+      () => undefined,
+      () => undefined
+    )
+    pathLocks.set(filePath, guard)
+    void guard.then(() => {
+      if (pathLocks.get(filePath) === guard) pathLocks.delete(filePath)
+    })
+    return run
+  }
+
+  function forget(filePath: string): void {
+    const entry = entries.get(filePath)
+    if (entry) {
+      totalCacheSize -= entry.size
+      entries.delete(filePath)
+    }
+  }
+
+  // Unlinks an evicted cache file under the path lock, re-checking the entry is still current: a
+  // store may have promoted the path to primary content (forgetting the entry) between the eviction
+  // scan and this delete — unlinking then would destroy the only copy of the new content.
+  async function evictEntry(filePath: string, entry: { size: number; lastAccess: number }): Promise<void> {
+    await withPathLock(filePath, async () => {
+      if (entries.get(filePath) !== entry) return
+      await noFailUnlink(filePath)
+      // Keep the tracking when the file survives the unlink, so the next eviction tick retries it
+      // instead of leaving an untracked (unaccounted, never-retried) cache file on disk.
+      if (await existsForInvariant(filePath)) return
+      totalCacheSize -= entry.size
+      entries.delete(filePath)
+    })
+  }
+
+  async function runEviction() {
+    const now = Date.now()
+
+    // TTL eviction
+    for (const [filePath, entry] of entries) {
+      if (now - entry.lastAccess > options.ttl) {
+        await evictEntry(filePath, entry)
+      }
+    }
+
+    // Size eviction (LRU)
+    if (totalCacheSize > options.maxSize) {
+      const sorted = [...entries.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess)
+      for (const [filePath, entry] of sorted) {
+        if (totalCacheSize <= options.maxSize) break
+        await evictEntry(filePath, entry)
+      }
+    }
+  }
+
+  // Returns the CURRENT in-flight eviction when one is already running, instead of a resolved
+  // no-op: the interval callback assigns this to the tracked tick, so a tick firing during a slow
+  // eviction must hand back the real promise — otherwise stop() would await the no-op and could
+  // resolve while the actual eviction is still unlinking files.
+  let inflightEviction: Promise<void> | undefined
+  function evict(): Promise<void> {
+    if (inflightEviction) return inflightEviction
+    inflightEviction = runEviction()
+      .catch((error) => logger.warn(`Cache eviction failed: ${error}`))
+      .finally(() => {
+        inflightEviction = undefined
+      })
+    return inflightEviction
+  }
+
+  return {
+    withPathLock,
+    forget,
+    evict,
+    inflight: () => inflightDecompressions.values(),
+    invalidateInflight(filePath: string): void {
+      const token = inflightTokens.get(filePath)
+      if (token) token.invalidated = true
+    },
+    deduplicateInflation(filePath: string, inflate: (token: InvalidationToken) => Promise<void>): Promise<void> {
+      let pending = inflightDecompressions.get(filePath)
+      const isOwner = !pending
+      if (!pending) {
+        pending = (async () => {
+          const token: InvalidationToken = { invalidated: false }
+          inflightTokens.set(filePath, token)
+          try {
+            await inflate(token)
+          } finally {
+            if (inflightTokens.get(filePath) === token) {
+              inflightTokens.delete(filePath)
+            }
+          }
+        })()
+        inflightDecompressions.set(filePath, pending)
+      }
+      return pending.finally(() => {
+        if (isOwner) inflightDecompressions.delete(filePath)
+      })
+    },
+    record(filePath: string, size: number): void {
+      entries.set(filePath, { size, lastAccess: Date.now() })
+      totalCacheSize += size
+    },
+    async remove(filePath: string): Promise<boolean> {
+      const entry = entries.get(filePath)
+      if (!entry) return false
+      await noFailUnlink(filePath)
+      // Verify before dropping the tracking: reporting the cached raw as handled while it survives
+      // would let delete() remove the gzip and resolve — resurrecting the untracked cache file as
+      // readable primary content after a "successful" delete.
+      if (await existsForInvariant(filePath)) {
+        throw new Error(`Failed to remove the cached decompressed content at ${filePath}`)
+      }
+      totalCacheSize -= entry.size
+      entries.delete(filePath)
+      return true
+    },
+    touch(filePath: string): void {
+      const entry = entries.get(filePath)
+      if (entry) {
+        entry.lastAccess = Date.now()
+      }
+    },
+    async evictAll(): Promise<void> {
+      for (const [filePath, entry] of entries) {
+        await evictEntry(filePath, entry)
+      }
+    }
+  }
+}

--- a/src/folder-based/fs-invariants.ts
+++ b/src/folder-based/fs-invariants.ts
@@ -1,0 +1,45 @@
+import { IFileSystemComponent } from '../fs/types'
+
+/**
+ * The two filesystem primitives the recovery paths are built on. Bound to one filesystem component
+ * so every caller shares the exact same semantics — the difference between them is load-bearing:
+ * `existsForInvariant` must distinguish "absent" from "cannot tell", while `noFailUnlink` is
+ * deliberately best-effort and callers verify the outcome themselves.
+ */
+export type FsInvariants = {
+  /**
+   * Existence check for recovery invariants. `existPath()` tests F_OK|R_OK, so a file left behind by
+   * a failed unlink in an UNREADABLE state (mode/ACL damage, transient permission problem) would
+   * read as absent — letting a must-succeed cleanup be falsely considered complete, and the mixed
+   * state resurface later with no repair signal. Here only ENOENT/ENOTDIR mean absent; any other
+   * error fails the repair/commit path loudly.
+   */
+  existsForInvariant(target: string): Promise<boolean>
+  /**
+   * Best-effort unlink reporting whether it removed the file. Never throws: every caller that needs
+   * certainty re-checks with `existsForInvariant` and decides what a survivor means.
+   */
+  noFailUnlink(target: string): Promise<boolean>
+}
+
+export function createFsInvariants(fs: IFileSystemComponent): FsInvariants {
+  return {
+    async existsForInvariant(target: string): Promise<boolean> {
+      try {
+        await fs.stat(target)
+        return true
+      } catch (err: any) {
+        if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') return false
+        throw err
+      }
+    },
+    async noFailUnlink(target: string): Promise<boolean> {
+      try {
+        await fs.unlink(target)
+        return true
+      } catch (error) {
+        return false
+      }
+    }
+  }
+}

--- a/src/folder-based/intent-journal.ts
+++ b/src/folder-based/intent-journal.ts
@@ -1,0 +1,566 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { createHash, randomBytes } from 'crypto'
+import path from 'path'
+import { pipeline, Readable } from 'stream'
+import { promisify } from 'util'
+import { markAsNonCancellationError } from '../cancellation'
+import { IFileSystemComponent } from '../fs/types'
+import { FsInvariants } from './fs-invariants'
+
+const pipe = promisify(pipeline)
+
+/**
+ * Thrown when a commit rename failed AND its pre-rename intent could not be cleared. The staged
+ * file it names is then the only PROOF that the rename never landed: callers must preserve that
+ * exact path (instead of their usual staging cleanup), so the next construction can discard the
+ * intent as pre-rename instead of applying the failed commit as a completed transition.
+ */
+export class UncommittedIntentSurvivedError extends Error {
+  constructor(
+    readonly stagedPath: string,
+    message: string
+  ) {
+    super(message)
+  }
+}
+
+/**
+ * Reserved directory (under the storage root) where an atomic `storeStream` stages its temp file
+ * before renaming it into place. Kept out of the content namespace — a shard is a 4-hex directory and
+ * content lives in files, never here — so a temp can never collide with, hide, or be mistaken for an
+ * addressable id. Skipped by `allFileIds` and cleaned at startup. Its name is therefore reserved.
+ */
+export const TEMP_DIR_NAME = '.tmp-writes'
+
+// Matches exactly the names newTempPath generates (`<16-hex bootId>-<32-hex random>`). The startup
+// sweep deletes ONLY files of this shape: anything else under the reserved dir is not ours to
+// remove — in flat (disablePrefixHash) mode a deployment that predates the reservation may hold
+// legitimate content there, and deleting unrecognized files would turn an upgrade into data loss.
+const STAGED_FILE_NAME = /^[0-9a-f]{16}-[0-9a-f]{32}$/
+
+// Matches the intent-journal files a representation-transition commit writes (`<40-hex
+// sha1(id)>.intent`). An intent records which representation (raw|gzip) is the NEW primary for an
+// id, so a crash between the commit rename and the counterpart cleanup is reconciled at the next
+// construction instead of leaving mixed versions that reads could prefer. The path is a
+// deterministic function of the id: at most one intent can ever exist per id (commits are
+// serialized per path, and construction reconciles before any write), so reconciliation needs no
+// ordering heuristics.
+const INTENT_FILE_NAME = /^[0-9a-f]{40}\.intent$/
+
+const OWNERSHIP_MARKER = '.owned-by-catalyst-storage'
+const OWNERSHIP_MARKER_CONTENT = 'reserved by catalyst-storage for atomic write staging\n'
+
+/** Which of an id's two representations a commit is making primary. */
+export type Representation = 'raw' | 'gzip'
+
+/**
+ * The staging area and its crash-recovery journal.
+ *
+ * A logical object spans two canonical paths (`<id>` and `<id>.gzip`) but only one rename can be
+ * atomic, so a representation transition is journaled: an intent naming the new primary is written
+ * before the commit rename and discharged once the counterpart is provably gone. A crash (or a
+ * failed cleanup) in between leaves the journal behind, and the next construction resolves the
+ * mixed state in favor of the representation the intent names — instead of reads silently preferring
+ * the stale counterpart.
+ *
+ * Every method here is a no-op or a refusal in non-atomic mode: without `fs.rename` nothing stages,
+ * so there is nothing to journal, sweep or reconcile.
+ */
+export type IntentJournal = {
+  /** A fresh staged path under the reserved directory, tagged with this instance's boot id. */
+  newTempPath(): string
+  /**
+   * Commits a staged file onto its canonical primary path and removes the other representation.
+   * Must be called while holding the path lock for `primaryPath`.
+   */
+  commitRepresentation(
+    op: Representation,
+    id: string,
+    stagedPath: string,
+    primaryPath: string,
+    counterpartPath: string,
+    rename: (from: string, to: string) => Promise<void>,
+    signal?: AbortSignal
+  ): Promise<void>
+  /**
+   * Applies a pending intent for this id if one exists, so a caller never overwrites an unapplied
+   * repair instruction. Throws when the repair cannot be completed.
+   */
+  repairPendingIntent(id: string): Promise<void>
+  /** Verifies no journal is left for this id, throwing with `context` when one survives. */
+  assertNoIntent(id: string, context: string): Promise<void>
+  /**
+   * Whether reads must not serve this id: a post-rename counterpart cleanup failed in THIS process,
+   * so the on-disk state is mixed. An O(1) lookup with no syscalls — the read path is untouched
+   * while nothing is quarantined.
+   */
+  isQuarantined(id: string): boolean
+  /**
+   * Repair gate for reads of a quarantined id: applies the pending intent under the path lock and
+   * reports whether the id is safe to serve. Never throws — an unrepairable id stays quarantined and
+   * the caller reports no result rather than exposing a known-mixed state.
+   */
+  ensureReconciled(id: string): Promise<boolean>
+  /**
+   * Resolves mixed raw/gzip states left by a crash between a commit rename and its counterpart
+   * cleanup. Runs at construction, before any operation can observe the storage.
+   */
+  reconcile(): Promise<void>
+  /** Removes staged files left behind by writes interrupted in a previous run. Best-effort. */
+  sweepOrphanedTempFiles(): Promise<number>
+}
+
+export type IntentJournalOptions = {
+  /** The reserved staging directory, already validated as a single segment under the root. */
+  tempDir: string
+  /** Its basename, used verbatim in the operator-facing refusal messages. */
+  tempDirName: string
+  /** False in legacy no-rename mode, where none of the staging machinery applies. */
+  atomic: boolean
+  /** False in `disablePrefixHash` mode, where the root itself is the content namespace. */
+  useHashPrefix: boolean
+}
+
+/**
+ * Prepares the reserved staging directory (refusing to start if it cannot be proven safe to use) and
+ * returns the journal over it. Performs filesystem mutations, so callers must validate all
+ * configuration first.
+ */
+export async function createIntentJournal(
+  components: {
+    fs: IFileSystemComponent
+    logger: ILoggerComponent.ILogger
+    fsInvariants: FsInvariants
+    /** Serializes commits on a canonical path; supplied by the decompress cache. */
+    withPathLock: <T>(filePath: string, fn: () => Promise<T>) => Promise<T>
+    /** Maps an id to its canonical raw path. Called lazily, never during construction. */
+    resolveFilePath: (id: string) => Promise<string>
+  },
+  options: IntentJournalOptions
+): Promise<IntentJournal> {
+  const { fs, logger, withPathLock, resolveFilePath } = components
+  const { existsForInvariant, noFailUnlink } = components.fsInvariants
+  const { tempDir, tempDirName, atomic, useHashPrefix } = options
+
+  if (atomic) {
+    // stat() follows symlinks, so a pre-existing symlink at the reserved path would pass the
+    // directory check below and route staged writes and the startup sweep OUTSIDE the storage
+    // root. Refuse it when the fs component can detect it (lstat is optional for custom adapters;
+    // without it, the documented exclusive-root operational model is the guarantee).
+    if (fs.lstat) {
+      let linkStat
+      try {
+        linkStat = await fs.lstat(tempDir)
+      } catch {
+        linkStat = undefined
+      }
+      if (linkStat?.isSymbolicLink()) {
+        throw new Error(
+          `Refusing to start: the reserved temp path '${tempDirName}' is a symbolic link; staged writes and the ` +
+            `startup sweep would operate outside the storage root. Replace it with a real directory or configure ` +
+            `a different tempDirectoryName.`
+        )
+      }
+    }
+    // A legacy flat-mode content id could live exactly AT the reserved path as a file; mkdir would
+    // then fail with a low-level filesystem error. Detect it first and give the same actionable
+    // guidance as the other reservation conflicts.
+    if (await fs.existPath(tempDir)) {
+      const tempDirStat = await fs.stat(tempDir)
+      if (!tempDirStat.isDirectory()) {
+        throw new Error(
+          `Refusing to start: the reserved temp path '${tempDirName}' under the storage root exists as a file — ` +
+            `likely a pre-existing content id. Migrate it out or configure a different tempDirectoryName.`
+        )
+      }
+    }
+    // Created up front so storeStream can stage into it without a per-write mkdir.
+    await fs.mkdir(tempDir, { recursive: true })
+  }
+
+  // Construction invariant: the storage never runs in a state where the reserved staging namespace
+  // could hide addressable content. With hash prefixes, ids can never resolve into the reserved dir
+  // (containment sends them under a shard), so everything inside is ours by construction. In flat
+  // (disablePrefixHash) mode the root IS the content namespace, so ownership must be proven, and
+  // the marker's mere EXISTENCE is not proof: before the reservation, the marker path itself was a
+  // valid content id, so a legacy deployment could hold an arbitrary file there. Ownership requires
+  // ALL of: the marker exists, its bytes are exactly what this storage writes, and every other
+  // entry matches the staged-name shape this storage generates. Anything else — an unmarked
+  // non-empty directory, a marker with foreign content, an unrecognized sibling, or a failure to
+  // establish ownership — REFUSES TO START instead of warning-and-hiding: pre-existing ids under
+  // the reserved name would otherwise be silently unreachable (or, shape-matching ones, sweepable)
+  // after an upgrade. A byte-exact forgery of the marker alongside exclusively staged-shaped
+  // siblings is indistinguishable from genuine ownership by construction and is treated as opt-in.
+  // This also means the orphan sweep never needs a runtime ownership check.
+  if (atomic && !useHashPrefix) {
+    const markerPath = path.join(tempDir, OWNERSHIP_MARKER)
+    const refuseToStart = (reason: string): never => {
+      throw new Error(
+        `Refusing to start: ${reason} In disablePrefixHash mode the reserved temp directory '${tempDirName}' may hold ` +
+          `pre-existing content ids that the reservation would hide from retrieval and enumeration. ` +
+          `Migrate those files out of '${tempDirName}', configure a different tempDirectoryName, or restore the ` +
+          `'${OWNERSHIP_MARKER}' marker (with its original content) if they are staging leftovers from a previous run.`
+      )
+    }
+    if (await fs.existPath(markerPath)) {
+      const markerBody = await fs.readFile(markerPath, 'utf8')
+      if (markerBody !== OWNERSHIP_MARKER_CONTENT) {
+        refuseToStart(
+          `the ownership marker '${OWNERSHIP_MARKER}' exists but its content is not the one this storage writes, ` +
+            `so it may be a pre-existing content id rather than a marker.`
+        )
+      }
+      const foreign = (await fs.readdir(tempDir)).filter(
+        (entry) => entry !== OWNERSHIP_MARKER && !STAGED_FILE_NAME.test(entry) && !INTENT_FILE_NAME.test(entry)
+      )
+      if (foreign.length > 0) {
+        refuseToStart(
+          `the reserved temp directory '${tempDirName}' contains ${foreign.length} file(s) that this storage ` +
+            `did not create.`
+        )
+      }
+    } else {
+      const entries = await fs.readdir(tempDir)
+      if (entries.length > 0) {
+        refuseToStart(
+          `the reserved temp directory '${tempDirName}' already contains ${entries.length} file(s) that this ` +
+            `storage cannot prove it owns.`
+        )
+      }
+      await pipe(Readable.from([Buffer.from(OWNERSHIP_MARKER_CONTENT)]), fs.createWriteStream(markerPath))
+    }
+  }
+
+  // Staged files are prefixed with a per-boot random id so the startup sweep can tell leftovers
+  // from previous runs (any other prefix) apart from files this instance is writing right now —
+  // a write racing the sweep can therefore never have its live staged file unlinked.
+  const bootId = randomBytes(8).toString('hex')
+  const newTempPath = (): string => path.join(tempDir, `${bootId}-${randomBytes(16).toString('hex')}`)
+
+  // Journal for representation-transition commits: written before the commit rename whenever a
+  // counterpart representation exists, removed once the counterpart is confirmed gone. A crash in
+  // between leaves the intent behind, and the next construction resolves the mixed state in favor
+  // of the representation the intent names (see reconcile). The path is a deterministic function of
+  // the id — at most one intent per id can ever exist, because commits are serialized per path and
+  // construction reconciles before any write — so reconciliation needs no ordering heuristics.
+  // Fresh-id writes — the overwhelmingly common case in content-addressed use — have no counterpart
+  // and never pay for an intent.
+  const intentPathFor = (id: string): string =>
+    path.join(tempDir, `${createHash('sha1').update(id).digest('hex')}.intent`)
+
+  // Ids whose post-rename counterpart cleanup failed in THIS process: the on-disk state is mixed
+  // (new primary + stale counterpart) with the intent preserved, and live reads must not serve it —
+  // non-range reads would prefer the stale counterpart while range reads see the new bytes. Reads
+  // check this set and, for a quarantined id, repair under the path lock or report the id
+  // unavailable. Entries clear on any successful repair (read-triggered, retried store, delete) and
+  // do not survive restarts, where construction-time reconciliation takes over.
+  const unreconciledIds = new Set<string>()
+
+  // After a FAILED commit rename, the pre-rename intent must be PROVABLY gone before the staged
+  // proof may be discarded. Both "the journal survived" and "the journal cannot be proven gone"
+  // (the verification stat itself fails) preserve the proof via the typed error — otherwise a raw
+  // EACCES would escape untyped, the callers' staging cleanup would destroy the staged file, and a
+  // later restart could misapply the surviving pre-rename intent as a committed transition.
+  async function clearIntentOrThrowPreservingProof(
+    intentPath: string,
+    stagedPath: string,
+    id: string,
+    originalError: unknown
+  ): Promise<void> {
+    await noFailUnlink(intentPath)
+    try {
+      if (!(await existsForInvariant(intentPath))) return
+    } catch {
+      // Could not prove the dangerous journal is gone; fall through and preserve the staged proof.
+    }
+    throw new UncommittedIntentSurvivedError(
+      stagedPath,
+      `Failed to commit ${id} AND failed to prove its intent journal was removed; the staged file is preserved ` +
+        `as proof the commit never landed, so a restart repairs this once the filesystem issue is fixed. ` +
+        `Original error: ${originalError instanceof Error ? originalError.message : String(originalError)}`
+    )
+  }
+
+  // Removing an intent journal is semantically must-succeed wherever it is called: a journal that
+  // outlives its purpose is later interpreted as a pending repair instruction. Centralized so the
+  // invariant cannot be accidentally weakened back into a best-effort unlink.
+  async function removeIntentOrThrow(intentPath: string, context: string): Promise<void> {
+    await noFailUnlink(intentPath)
+    if (await existsForInvariant(intentPath)) {
+      throw new Error(`${context}: the intent journal '${intentPath}' could not be removed.`)
+    }
+  }
+
+  async function writeIntent(op: Representation, id: string, stagedPath: string): Promise<string> {
+    const intentPath = intentPathFor(id)
+    // The staged BASENAME lets reconciliation prove whether the commit rename landed: renames
+    // consume the staged file, so "staged still present" means the rename provably never happened.
+    // Stored as a basename (not an absolute path) so a root remount cannot poison the journal.
+    const body = JSON.stringify({ op, id, staged: path.basename(stagedPath) })
+    await pipe(Readable.from([Buffer.from(body)]), fs.createWriteStream(intentPath))
+    return intentPath
+  }
+
+  // Applies a pending intent, distinguishing the two crash windows by the staged file the intent
+  // names (reconciliation runs before the sweep, so a crashed boot's staged file is still there):
+  // - staged file present  → the rename never happened: discard the staged file and the intent; the
+  //   previous representation(s) stay untouched. A pre-rename intent can therefore NEVER delete the
+  //   previous primary (e.g. a valid gzip alongside its own decompressed raw cache).
+  // - staged gone, primary present → the rename landed: remove the stale counterpart (throwing when
+  //   it cannot be removed — live reads do not consult intents and would keep serving it), then
+  //   discharge the intent.
+  // - neither → nothing can be proven: refuse, manual repair required.
+  // Used by construction-time reconciliation and by commits that find a pending intent for their id
+  // (a failed cleanup earlier in this process), so an unapplied repair instruction is never
+  // overwritten.
+  async function applyPendingIntent(intentPath: string): Promise<void> {
+    const body = await fs.readFile(intentPath, 'utf8')
+    let op: string, id: string, staged: string
+    try {
+      ;({ op, id, staged } = JSON.parse(body))
+    } catch {
+      op = id = staged = ''
+    }
+    if (
+      (op !== 'raw' && op !== 'gzip') ||
+      !id ||
+      !STAGED_FILE_NAME.test(staged ?? '') ||
+      // The intent path is a deterministic function of the id: a body whose id does not hash to
+      // this filename is corruption or operator error, and applying it would reconcile the WRONG
+      // id. Treat it as malformed.
+      intentPathFor(id) !== intentPath
+    ) {
+      // A partial/malformed intent means its commit never started (intents are written before
+      // renames): discard it; an orphaned staged file, if any, is handled by the sweep.
+      await removeIntentOrThrow(intentPath, 'Discarding a malformed intent journal failed')
+      return
+    }
+    const stagedPath = path.join(tempDir, staged)
+    if (await existsForInvariant(stagedPath)) {
+      // Prepared but never renamed: the commit did not happen. The staged file is the PROOF of
+      // that, and the intent is the dangerous artifact — remove the journal first (must succeed),
+      // and only then the inert staged garbage. The reverse order could destroy the proof while the
+      // journal survives, letting the next construction reinterpret this pre-rename intent as a
+      // committed transition and delete the valid counterpart.
+      await removeIntentOrThrow(intentPath, `Cannot discard the uncommitted ${op} intent for ${id}`)
+      await noFailUnlink(stagedPath)
+      unreconciledIds.delete(id)
+      logger.info(`Discarded a prepared but uncommitted ${op} transition`, { id })
+      return
+    }
+    const filePath = await resolveFilePath(id)
+    const gzipPath = filePath + '.gzip'
+    const primaryPath = op === 'raw' ? filePath : gzipPath
+    const counterpartPath = op === 'raw' ? gzipPath : filePath
+    if (!(await existsForInvariant(primaryPath))) {
+      throw new Error(
+        `Cannot reconcile the interrupted ${op} commit for ${id}: neither its staged file nor its committed ` +
+          `representation exists.`
+      )
+    }
+    if (await existsForInvariant(counterpartPath)) {
+      await noFailUnlink(counterpartPath)
+      if (await existsForInvariant(counterpartPath)) {
+        throw new Error(
+          `Cannot repair the interrupted ${op} commit for ${id}: its stale ${
+            op === 'raw' ? 'gzip' : 'raw'
+          } representation could not be removed.`
+        )
+      }
+      logger.info(`Reconciled an interrupted ${op} commit`, { id })
+    }
+    await removeIntentOrThrow(intentPath, `Reconciled ${id} but could not discharge its intent journal`)
+    unreconciledIds.delete(id)
+  }
+
+  async function repairPendingIntent(id: string): Promise<void> {
+    if (!atomic) return
+    const intentPath = intentPathFor(id)
+    if (await existsForInvariant(intentPath)) {
+      await applyPendingIntent(intentPath)
+    }
+  }
+
+  async function doCommitRepresentation(
+    op: Representation,
+    id: string,
+    stagedPath: string,
+    primaryPath: string,
+    counterpartPath: string,
+    rename: (from: string, to: string) => Promise<void>,
+    signal?: AbortSignal
+  ): Promise<void> {
+    // A pending intent means a previous commit for this id failed its cleanup in this process:
+    // repair first (throws if impossible), so the intent written below always describes a
+    // transition from a consistent state and never overwrites an unapplied repair instruction.
+    await repairPendingIntent(id)
+    // The pre-rename phase awaits repair, existence checks and the journal write: an abort landing
+    // during any of them (with the source long consumed) must still cancel before the irreversible
+    // rename. Here no commit artifact exists yet, so a plain throw suffices; a completed repair
+    // above is idempotent state that needs no undoing.
+    signal?.throwIfAborted()
+    const hadCounterpart = await existsForInvariant(counterpartPath)
+    const intentPath = hadCounterpart ? await writeIntent(op, id, stagedPath) : undefined
+    if (intentPath && signal?.aborted) {
+      // Cancelled after the intent was journaled but before the rename: the commit never happened,
+      // so the journal must not survive (a later repair would apply it as a completed transition).
+      // Clearing it is must-succeed — if it cannot be cleared, the staged file is preserved as the
+      // proof the rename never landed, exactly like a failed rename.
+      await clearIntentOrThrowPreservingProof(intentPath, stagedPath, id, signal.reason)
+    }
+    // Unconditional last checkpoint before the irreversible rename: without it, an abort landing
+    // during the awaited counterpart check on a fresh id (no counterpart → no intent → the block
+    // above skipped) would proceed to commit. No journal exists past this line unless it was just
+    // cleared, so a plain throw is safe.
+    signal?.throwIfAborted()
+    try {
+      await rename(stagedPath, primaryPath)
+    } catch (err) {
+      // The commit did not happen, so the intent must not survive it: a later repair would treat
+      // the failed commit as successful and remove the counterpart — e.g. delete a valid gzip
+      // primary in favor of its own decompressed raw cache.
+      if (intentPath) {
+        // A surviving (or unprovably-removed) intent could later be applied as if the commit
+        // succeeded. The staged file is the proof it did not — the typed error tells callers to
+        // preserve it, which also makes this state self-healing: the next construction sees the
+        // staged file, classifies the intent as pre-rename and discards both, previous
+        // representations untouched.
+        await clearIntentOrThrowPreservingProof(intentPath, stagedPath, id, err)
+      }
+      throw err
+    }
+    if (hadCounterpart) {
+      await noFailUnlink(counterpartPath)
+      let counterpartGone: boolean
+      try {
+        counterpartGone = !(await existsForInvariant(counterpartPath))
+      } catch (verifyErr) {
+        // Possibly mixed and unprovable: quarantine so reads repair-or-refuse instead of serving it.
+        unreconciledIds.add(id)
+        throw verifyErr
+      }
+      if (!counterpartGone) {
+        // The new version is committed, but the stale counterpart could not be removed. The
+        // on-disk state is MIXED: without a guard, non-range reads would keep preferring the stale
+        // counterpart while range reads see the new bytes — two versions of one id from the same
+        // process. Quarantine the id (reads repair-or-refuse, see ensureReconciled) and fail the
+        // store loudly; the intent survives, so a retried store, a read-triggered repair or the
+        // next construction finishes the cleanup.
+        unreconciledIds.add(id)
+        throw new Error(
+          `Stored ${id} but failed to remove its previous ${op === 'raw' ? 'gzip' : 'raw'} representation; ` +
+            `the id is quarantined from reads until a retry, read-triggered repair or restart completes the cleanup.`
+        )
+      }
+      if (intentPath) {
+        await removeIntentOrThrow(intentPath, `Committed ${id} but could not discharge its intent journal`)
+      }
+      unreconciledIds.delete(id)
+    }
+  }
+
+  return {
+    newTempPath,
+    repairPendingIntent,
+    isQuarantined: (id: string) => unreconciledIds.has(id),
+
+    // Commits a staged file onto its canonical primary path and removes the other representation.
+    // The logical object spans two paths (raw and .gzip) but only the rename is atomic, so when a
+    // counterpart exists an intent is journaled FIRST: if the process dies (or the unlink fails)
+    // between the rename and the cleanup, the next construction reconciles the mixed state in favor
+    // of the representation committed here, instead of reads preferring the stale counterpart. Must
+    // be called while holding the path lock.
+    async commitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename, signal): Promise<void> {
+      try {
+        await doCommitRepresentation(op, id, stagedPath, primaryPath, counterpartPath, rename, signal)
+      } catch (err) {
+        // The commit phase's own cancellation checkpoints throw the caller's abort reason and nothing
+        // else, so identity is the whole test: pass that through untouched (it IS a cancellation, and
+        // marking would tag a caller-owned object with this module's internal symbol). Every other
+        // failure here — pending-intent repair, journal write, rename, counterpart cleanup, quarantine
+        // — cannot be caused by abort teardown (the source is fully consumed before any commit begins
+        // and this backend has no abort hook), so it is a real storage error that cancellation
+        // translation must never mask, whatever shape it happens to have.
+        if (signal?.aborted && err === signal.reason) {
+          throw err
+        }
+        throw markAsNonCancellationError(err)
+      }
+    },
+
+    async assertNoIntent(id: string, context: string): Promise<void> {
+      if (!atomic) return
+      await removeIntentOrThrow(intentPathFor(id), context)
+    },
+
+    async ensureReconciled(id: string): Promise<boolean> {
+      if (!unreconciledIds.has(id)) return true
+      const filePath = await resolveFilePath(id)
+      return withPathLock(filePath, async () => {
+        if (!unreconciledIds.has(id)) return true
+        try {
+          const intentPath = intentPathFor(id)
+          if (await existsForInvariant(intentPath)) {
+            await applyPendingIntent(intentPath)
+          } else {
+            // No journal left: the mixed state was repaired elsewhere (retried store, delete).
+            unreconciledIds.delete(id)
+          }
+          return !unreconciledIds.has(id)
+        } catch {
+          return false
+        }
+      })
+    },
+
+    async reconcile(): Promise<void> {
+      // No intents are ever written without atomic-write support.
+      if (!atomic) return
+      let entries: string[]
+      try {
+        entries = await fs.readdir(tempDir)
+      } catch {
+        return
+      }
+      // Intent paths are a deterministic function of the id, so there is at most one per id and no
+      // ordering to resolve. A repair that cannot be completed FAILS CONSTRUCTION: live reads do not
+      // consult intents, so a usable instance over an unreconciled mixed state would keep serving the
+      // stale representation for its whole lifetime.
+      for (const name of entries.filter((entry) => INTENT_FILE_NAME.test(entry)).sort()) {
+        try {
+          await applyPendingIntent(path.join(tempDir, name))
+        } catch (err: any) {
+          throw new Error(
+            `Refusing to start: ${err instanceof Error ? err.message : String(err)} ` +
+              `The intent journal '${name}' under '${tempDirName}' was kept; fix the underlying filesystem issue ` +
+              `(permissions, immutability) and restart.`
+          )
+        }
+      }
+    },
+
+    // Removes temp files left behind by writes interrupted in a previous run. Staged filenames carry
+    // this boot's random prefix, so a staged-shape file with a different prefix is by construction a
+    // leftover of an earlier process — a write racing this sweep stages under the current bootId and
+    // is never touched. Best-effort: a missing dir or a failed unlink is ignored.
+    async sweepOrphanedTempFiles(): Promise<number> {
+      // No staging happens without atomic-write support, so there is nothing of ours to sweep — and
+      // the directory (if it exists at all) is not ours to touch.
+      if (!atomic) return 0
+      // Ownership of the reserved dir is a construction invariant (see the OWNERSHIP_MARKER logic
+      // above): if this storage is running, everything staged-shaped in there is ours.
+      let entries: string[]
+      try {
+        entries = await fs.readdir(tempDir)
+      } catch {
+        return 0
+      }
+      let removed = 0
+      for (const entry of entries) {
+        if (!STAGED_FILE_NAME.test(entry) || entry.startsWith(`${bootId}-`)) continue
+        if (await noFailUnlink(path.join(tempDir, entry))) removed++
+      }
+      return removed
+    }
+  }
+}


### PR DESCRIPTION
Addresses item 1 of #110. Pure refactor — no behavior change, all tests pass unchanged.

## Why

`folder-based-storage-component.ts` had reached 1362 lines in a single closure. The crash-recovery journal, the decompression cache and the storage surface all shared one scope, so auditing any one invariant meant reading past the other two — and every invariant in there is subtle enough that this is exactly where a future fix drifts.

## What moved

Three internal modules under `src/folder-based/`:

**`fs-invariants.ts`** — `existsForInvariant` and `noFailUnlink`. Their difference is load-bearing: one must distinguish "absent" from "cannot tell" (an unreadable leftover must not read as gone), the other is deliberately best-effort with its callers verifying the outcome. One definition, one place explaining why.

**`intent-journal.ts`** — the staging area and its journal: preparing the reserved directory and proving ownership of it, writing and applying intents, the commit itself, the read quarantine for ids whose counterpart cleanup failed, construction-time reconciliation, and the orphan sweep. Non-atomic (no-`rename`) mode is handled inside the module, so the storage no longer threads `ATOMIC_MODE` through recovery call sites.

**`decompress-cache.ts`** — the tracked decompressed copies plus the concurrency control that keeps them from racing: the per-path lock, the invalidation tokens, in-flight deduplication, TTL/LRU eviction. These belong together: an entry is only created, promoted or evicted while its path is locked, and that is precisely what makes "is this file a derived cache or primary content?" a decidable question.

The component keeps what is genuinely storage: path resolution, the read paths, the store/compress flows, the public surface.

## Two simplifications the seams produced

- The commit's own pending-intent repair and `delete`'s were the same logic spelled twice; both are now `repairPendingIntent(id)`.
- A decompression's in-flight bookkeeping (register the promise, register the token, own-or-join, release both in the right `finally`) is now `deduplicateInflation`, which hands the inflation its token. It can no longer be half-applied by a future edit.

## Confidence

The suite asserts on-disk state and the public API rather than internals, so the existing 346 tests exercise the extraction rather than the wiring — they pass without modification. Component: 1362 → 796 lines.

Stacked on #112.
